### PR TITLE
fix: prevent keyboard toggling on tab switching

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset='utf-8'>
-	<meta name='description' content='EngineeringPaper.xyz is free Mathcad alternative for shareable engineering calculations that checks/converts units, solves systems of equations, and plots.'>
+	<meta name='description' content='EngineeringPaper.xyz is free and open source web app for creating shareable engineering calculations that checks/converts units, solves systems of equations, and plots.'>
 	<meta name='viewport' content='width=device-width,initial-scale=1'>
 	<meta name="googlebot" content="all" /> <!-- transformed by webworker to noindex,indexifembedded for sheet URL's--> 
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -176,6 +176,8 @@
   let autosaveIntervalId: null | number = null;
   let autosaveNeeded = false;
 
+  let showKeyboard = false;
+
   let inIframe = false;
 
   let fileDropActive = false;
@@ -1321,8 +1323,11 @@ Please include a link to this sheet in the email to assist in debugging the prob
     }
   }
 
-  function handleKeyboardExpanded() {
-    if ($activeMathField && $activeMathField.element)
+  function ensureMathFieldVisible(event: TransitionEvent | MouseEvent) {
+    if ( ( (event.target === document.getElementById('keyboard-tray') && event instanceof TransitionEvent)
+           || event instanceof MouseEvent ) 
+        && $activeMathField
+        && $activeMathField.element )
     {
       if ( !isVisible(
                $activeMathField.element.getMathField().el(),
@@ -1331,7 +1336,7 @@ Please include a link to this sheet in the email to assist in debugging the prob
         $activeMathField.element.getMathField().el().scrollIntoView({
             behavior: "smooth",
             block: "center"
-          });
+        });
       }
     }
   }
@@ -1341,6 +1346,12 @@ Please include a link to this sheet in the email to assist in debugging the prob
       window.history.pushState(null, "", path)
       e.preventDefault();
       refreshSheet();
+    }
+  }
+
+  $:{
+    if (document.hasFocus() && showKeyboard !== Boolean($activeMathField)) {
+      showKeyboard = Boolean($activeMathField);
     }
   }
 
@@ -1831,9 +1842,9 @@ Please include a link to this sheet in the email to assist in debugging the prob
   <div
     id="keyboard-tray" 
     class:inIframe
-    style={`height: ${$activeMathField && !inIframe ? 'var(--keyboard-tray-height)' : '0px'}`}
-    on:transitionend={handleKeyboardExpanded}
-    on:mousedown={(event) => event.preventDefault()}
+    style={`height: ${showKeyboard && !inIframe ? 'var(--keyboard-tray-height)' : '0px'}`}
+    on:transitionend={ensureMathFieldVisible}
+    on:mousedown={ (event) => {event.preventDefault(); ensureMathFieldVisible(event);} }
   >
     <VirtualKeyboard keyboards={keyboards}/>
   </div>

--- a/src/VirtualKeyboard.svelte
+++ b/src/VirtualKeyboard.svelte
@@ -26,6 +26,7 @@
     background-color: white;
     cursor: pointer;
     padding: 0px;
+    transition: 0.3s;
   }
   
   :global(button.keyboard span) {

--- a/tests/test_parse_id_bug.spec.mjs
+++ b/tests/test_parse_id_bug.spec.mjs
@@ -22,9 +22,9 @@ test('Test parse id bug', async ({ page, browserName }) => {
   // await page.setViewportSize({ width: width, height: height });
 
   await page.goto('/DuGYz5Lu7tPdEJ27zAT8bg');
-  await page.locator('h3 >> text=Retrieving Sheet').waitFor({state: 'detached', timeout: 5000});
+  await page.locator('h3 >> text=Retrieving Sheet').waitFor({state: 'detached'});
 
-  await page.locator('h1 >> text=Calculating the Johnson-Euler Buckling Load').waitFor({state: 'visible', timeout: 10000});
+  await page.locator('h1 >> text=Calculating the Johnson-Euler Buckling Load').waitFor({state: 'visible'});
   await page.locator("text=Accept").click();
 
   await page.forceDeleteCell(0);


### PR DESCRIPTION
This was causing page position to jump when switching tabs. Also, ensure active math field is visible when pressing virtual keyboard buttons.
