### PR TITLE
fix: fix file association launch with Edge

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -129,6 +129,7 @@ export default [
 				],
 				navigateFallback: "index.html",
 				navigateFallbackAllowlist: [/^\/[a-zA-Z0-9]{22}$/, /^\/temp-checkpoint-.*$/, /^\/open_file$/],
+				ignoreURLParametersMatching: [/^activation$/],
 				maximumFileSizeToCacheInBytes: 40*1000**2,
 				inlineWorkboxRuntime: true,
 				sourcemap: !production,


### PR DESCRIPTION
Edge does not respect the file_handlers action parameter and uses the activation=file search param instead. The Edge default is now supported as well as the /open_file path specified in the manifest.json

Edge file association should start working after installed app updated to the latest version

