### PR TITLE
fix: show file opening modal earlier in process at launch

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -641,6 +641,7 @@
         currentState = `/${hash}`;
         if (firstTime && ( window.location.pathname === "/open_file" || 
                            searchParams.get('activation') === "file") ) {
+          modalInfo = {state: "opening", modalOpen: true, heading: "Opening File"};
           await initializeBlankSheet();  // ensure minimal sheet is loaded in case file load fails or launch queue is empty
           window.history.replaceState(null, "", "/");
           if ('launchQueue' in window) {
@@ -651,6 +652,8 @@
               const fileHandle = launchParams.files[0];
               openSheetFromFileHandle(fileHandle);
             });
+          } else {
+            modalInfo.modalOpen = false; // launchQueue not supported by browser, close file open modal
           }
         } else if (hash.startsWith(checkpointPrefix)) {
           currentStateObject = window.history.state;

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1035,12 +1035,6 @@ Please include a link to this sheet in the email to assist in debugging the prob
     }
   }
 
-  function handleDragEnter(event: DragEvent) {
-    if (event.dataTransfer.items[0]?.kind === "file") { 
-      fileDropActive = !modalInfo.modalOpen 
-    }
-  }
-
   // open sheet from a drop event
   async function handleFileDrop(event: DragEvent) {
     fileDropActive = false;
@@ -1948,7 +1942,7 @@ Please include a link to this sheet in the email to assist in debugging the prob
   class="page"
   class:inIframe
 	on:dragover|preventDefault
-	on:dragenter={ handleDragEnter }
+	on:dragenter={e => fileDropActive = !modalInfo.modalOpen}
 >
   <Header
     bind:isSideNavOpen={sideNavOpen}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1035,6 +1035,12 @@ Please include a link to this sheet in the email to assist in debugging the prob
     }
   }
 
+  function handleDragEnter(event: DragEvent) {
+    if (event.dataTransfer.items[0]?.kind === "file") { 
+      fileDropActive = !modalInfo.modalOpen 
+    }
+  }
+
   // open sheet from a drop event
   async function handleFileDrop(event: DragEvent) {
     fileDropActive = false;
@@ -1942,7 +1948,7 @@ Please include a link to this sheet in the email to assist in debugging the prob
   class="page"
   class:inIframe
 	on:dragover|preventDefault
-	on:dragenter={e => fileDropActive = !modalInfo.modalOpen}
+	on:dragenter={ handleDragEnter }
 >
   <Header
     bind:isSideNavOpen={sideNavOpen}


### PR DESCRIPTION
Current behavior is confusing where a blank sheet appears briefly before showing the sheet loaded from the file.