### PR TITLE
fix: don't trigger autosave on initial sheet calc

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -855,7 +855,9 @@
             $system_results[i] = data.systemResults[counter++]
           }
         }
-        $autosaveNeeded = true;
+        if (!firstRunAfterSheetLoad) {
+          $autosaveNeeded = true;
+        }
       })
       .catch((errorMessage) => error=errorMessage);
     }


### PR DESCRIPTION
For sheets that take a long time to calculate, it's good to trigger an autosave after the calc finishes. However, don't trigger autosave on initial calc since the URL then gets changed when the sheet hasn't changed.