### PR TITLE
fix: cell move inlineShortcuts bug

### DIFF
--- a/src/MathField.svelte
+++ b/src/MathField.svelte
@@ -4,6 +4,7 @@
   import type { MathField } from "./cells/MathField";
 
   import type { MathfieldElement } from "mathlive";
+  import { INLINE_SHORTCUTS } from "./constants";
 
   export let latex = "";
   export let mathField: MathField | null = null;
@@ -42,19 +43,7 @@
       mathLiveField.mathVirtualKeyboardPolicy = "manual";
       mathLiveField.inlineShortcutTimeout = 0;
       mathLiveField.smartSuperscript = false;
-      mathLiveField.inlineShortcuts = {
-          '*': '\\cdot',
-          '@': '\\times',
-          '<=': '\\le',
-          '>=': '\\ge',
-          '~': '\\approx',
-          'sqrt': '\\sqrt{#?}',
-          '$int': '\\int _{#?}^{#?}\\left(#?\\right)\\mathrm{d}\\left(#?\\right)',
-          '$prime': '\\frac{\\mathrm{d}}{\\mathrm{d}\\left(#?\\right)}\\left(#?\\right)',
-          '$doubleprime': '\\frac{\\mathrm{d}^{2}}{\\mathrm{d}\\left(#?\\right)^{2}}\\left(#?\\right)',
-          '$tripleprime': '\\frac{\\mathrm{d}^{3}}{\\mathrm{d}\\left(#?\\right)^{3}}\\left(#?\\right)',
-          'log_': '\\log_{#?}(#?)',
-        };
+      mathLiveField.inlineShortcuts = INLINE_SHORTCUTS;
 
       mathLiveField.keybindings = mathLiveField.keybindings
                                     .filter((value) => value.key !== '[Paste]' &&
@@ -150,6 +139,11 @@
     }
   }
 
+
+  // workaround needed for move cell inlineShortcuts bug
+  $: if (editable && mathLiveField && mathLiveField.inlineShortcuts) {
+    mathLiveField.inlineShortcuts = INLINE_SHORTCUTS;
+  }
 
   $: if (!editable && mathLiveField ) {
     mathLiveField.value = latex;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,13 @@
+export const INLINE_SHORTCUTS = {
+    '*': '\\cdot',
+    '@': '\\times',
+    '<=': '\\le',
+    '>=': '\\ge',
+    '~': '\\approx',
+    'sqrt': '\\sqrt{#?}',
+    '$int': '\\int _{#?}^{#?}\\left(#?\\right)\\mathrm{d}\\left(#?\\right)',
+    '$prime': '\\frac{\\mathrm{d}}{\\mathrm{d}\\left(#?\\right)}\\left(#?\\right)',
+    '$doubleprime': '\\frac{\\mathrm{d}^{2}}{\\mathrm{d}\\left(#?\\right)^{2}}\\left(#?\\right)',
+    '$tripleprime': '\\frac{\\mathrm{d}^{3}}{\\mathrm{d}\\left(#?\\right)^{3}}\\left(#?\\right)',
+    'log_': '\\log_{#?}(#?)',
+};

--- a/tests/test_basic.spec.mjs
+++ b/tests/test_basic.spec.mjs
@@ -1467,3 +1467,19 @@ test('Negative grouping with fractions with negative denominator', async () => {
   content = await page.textContent('#result-value-3');
   expect(content).toBe('b');
 });
+
+test('Test cell move inlineShortcuts bug', async () => {
+
+  await page.locator('#add-math-cell').click();
+
+  await page.locator('#up-1').click();
+
+  await page.locator('#cell-0 >> math-field.editable').type('1[mm]=[mm]');
+
+  await page.waitForSelector('.status-footer', { state: 'detached'});
+
+  let content = await page.textContent('#result-value-0');
+  expect(parseLatexFloat(content)).toBeCloseTo(1, precision);
+  content = await page.textContent('#result-units-0');
+  expect(content).toBe('mm');
+});


### PR DESCRIPTION
Temporary workaround to fix bug where moved cell loses its inlineShortcuts setting.

Not sure of the root cause of the issue, will look into whether switching to svelte 4 will fix the issue.
