### PR TITLE
fix: force margin behind sheet content for when cells overflow

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1957,10 +1957,14 @@ Please include a link to this sheet in the email to assist in debugging the prob
   #sheet {
     width: min(1000px, 100%);
     height: fit-content;
+    z-index: 2;
   }
 
   div.sheet-margin {
     flex-grow: 1;
+    position: sticky;
+    top: 0px;
+    z-index: 1;
   }
 
   #keyboard-tray {


### PR DESCRIPTION
Also, fixes margin click to unselect all for scrolled page
