### PR TITLE
test: try to add webkit tests to GitHub Actions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Start serving site for testing
       run: npm run start &
     - name: Install Playwright
-      run: npx playwright install chromium firefox --with-deps
+      run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: npm run test
     - uses: actions/upload-artifact@v3

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -43,8 +43,7 @@ const config = {
   },
 
   /* Set projects for CI and local environments */
-  projects: process.env.CI ? projectFactory(['chromium', 'firefox']) : 
-                             projectFactory(['chromium', 'firefox', 'webkit']),
+  projects: projectFactory(['chromium', 'firefox', 'webkit']),
 
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */
   outputDir: 'test-results/',


### PR DESCRIPTION
The new GitHub runners may be able to handle adding webkit tests. The old runners were not able to reliably handle the webkit runs.
