### PR TITLE
feat: add sheet setting to disable symbolic expression simplification

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2619,7 +2619,9 @@ Please include a link to this sheet in the email to assist in debugging the prob
         primaryButtonText="Confirm"
         secondaryButtonText="Restore Defaults"
         on:click:button--primary={() => modalInfo.modalOpen = false}
-        on:click:button--secondary={() => {mathCellConfigDialog?.resetDefaults(); baseUnitsConfigDialog?.resetDefaults();}}
+        on:click:button--secondary={() => {mathCellConfigDialog?.resetDefaults();
+                                           baseUnitsConfigDialog?.resetDefaults();
+                                           $config.simplifySymbolicExpressions = true;}}
         bind:open={modalInfo.modalOpen}
       >
         {#if modalInfo.mathCell}
@@ -2638,7 +2640,7 @@ Please include a link to this sheet in the email to assist in debugging the prob
                 <Checkbox 
                   labelText="Automatically Simplify Symbolic Expressions (unchecking will speed up sheet updates)"
                   bind:checked={$config.simplifySymbolicExpressions}
-                  on:change={() => $mathCellChanged = true}
+                  on:check={() => $mathCellChanged = true}
                 />
                 <MathCellConfigDialog
                   bind:this={mathCellConfigDialog}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -50,6 +50,7 @@
     SkipToContent,
     HeaderUtilities,
     HeaderGlobalAction,
+    Checkbox,
     Content,
     SideNav,
     SideNavMenuItem,
@@ -827,7 +828,12 @@
 
     statements.push(...endStatements);
 
-    return {statements: statements, systemDefinitions: systemDefinitions, customBaseUnits: $config.customBaseUnits};
+    return {
+      statements: statements,
+      systemDefinitions: systemDefinitions, 
+      customBaseUnits: $config.customBaseUnits,
+      simplifySymbolicExpressions: $config.simplifySymbolicExpressions
+    };
   }
 
   function checkParsingErrors() {
@@ -1087,9 +1093,8 @@ Please include a link to this sheet in the email to assist in debugging the prob
       // old documents in database will not have the insertedSheets property or a config property
       $insertedSheets = sheet.insertedSheets ?? [];
       $config = sheet.config ?? getDefaultConfig();
-      if (!$config.customBaseUnits) {
-        $config.customBaseUnits = getDefaultBaseUnits();
-      }
+      $config.customBaseUnits = $config.customBaseUnits ?? getDefaultBaseUnits(); // customBaseUnits may not exist
+      $config.simplifySymbolicExpressions = $config.simplifySymbolicExpressions ?? true; // simplifySymboicExpressions may not exist
     
       if (!$history.map(item => item.hash !== "file" ? getSheetHash(new URL(item.url)) : "").includes(getSheetHash(window.location))) {
         $history = requestHistory;
@@ -2630,6 +2635,11 @@ Please include a link to this sheet in the email to assist in debugging the prob
             <Tab label="Default Units" />
             <svelte:fragment slot="content">
               <TabContent>
+                <Checkbox 
+                  labelText="Automatically Simplify Symbolic Expressions (unchecking will speed up sheet updates)"
+                  bind:checked={$config.simplifySymbolicExpressions}
+                  on:change={() => $mathCellChanged = true}
+                />
                 <MathCellConfigDialog
                   bind:this={mathCellConfigDialog}
                   bind:mathCellConfig={$config.mathCellConfig}

--- a/src/sheet/Sheet.ts
+++ b/src/sheet/Sheet.ts
@@ -10,7 +10,7 @@ export type Sheet = {
   system_results: (SystemResult)[];
   nextId: number;
   sheetId: string;
-  insertedSheets?: InsertedSheet[]; // early sheets did not have an insertedSheets property  
+  insertedSheets?: InsertedSheet[]; // early sheets did not have this property  
 };
 
 export type InsertedSheet = {
@@ -21,7 +21,8 @@ export type InsertedSheet = {
 
 export type Config = {
   mathCellConfig: MathCellConfig;
-  customBaseUnits?: CustomBaseUnits; // same early sheets won't have this property
+  customBaseUnits?: CustomBaseUnits; // some early sheets won't have this property
+  simplifySymbolicExpressions?: boolean; // some early sheets won't have this property
 };
 
 type Notation = "auto" | "fixed" | "exponential" | "engineering";
@@ -41,7 +42,8 @@ type FormatOptions = {
 export function getDefaultConfig(): Config {
   return {
     mathCellConfig: getDefaultMathCellConfig(),
-    customBaseUnits: getDefaultBaseUnits()
+    customBaseUnits: getDefaultBaseUnits(),
+    simplifySymbolicExpressions: true
   };
 }
 

--- a/src/sheet/Sheet.ts
+++ b/src/sheet/Sheet.ts
@@ -80,7 +80,9 @@ export function isDefaultMathConfig(config: MathCellConfig): boolean {
 }
 
 export function isDefaultConfig(config: Config): boolean {
-  return isDefaultMathConfig(config.mathCellConfig) && isDefaultBaseUnits(config.customBaseUnits);
+  return isDefaultMathConfig(config.mathCellConfig) && 
+         isDefaultBaseUnits(config.customBaseUnits) &&
+         config.simplifySymbolicExpressions === true;
 }
 
 export function copyMathConfig(input: MathCellConfig): MathCellConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export type StatementsAndSystems = {
   statements: Statement[];
   systemDefinitions: SystemDefinition[];
   customBaseUnits?: CustomBaseUnits;
+  simplifySymbolicExpressions: boolean;
 }
 
 

--- a/tests/test_basic.spec.mjs
+++ b/tests/test_basic.spec.mjs
@@ -1295,19 +1295,6 @@ test('Check parsing error handling impact on displayed results', async () => {
 });
 
 
-test('Symbolic result canceling', async () => {
-
-  await page.setLatex(0, String.raw`-F-F_{B}-F_{W}-\frac{F\cdot l_4-F_{B}\cdot l_2+F_{W}\cdot l_3}{l_1+l_2}+\frac{F\cdot l_1+F\cdot l_2+F\cdot l_4+F_{B}\cdot l_1+F_{W}\cdot l_1+F_{W}\cdot l_2+F_{W}\cdot l_3}{l_1+l_2}\ =`);
-
-  await page.waitForSelector('.status-footer', { state: 'detached'});
-
-  // check query result in cell 1
-  let content = await page.textContent('#result-value-0');
-  expect(content).toBe('0');
-
-});
-
-
 test('Test single character square root', async () => {
 
   await page.locator('#cell-0 >> math-field.editable').type('sqrt4');

--- a/tests/test_number_format.spec.mjs
+++ b/tests/test_number_format.spec.mjs
@@ -89,6 +89,26 @@ test('Test symbolic format', async () => {
 
 });
 
+test('Test disabling automatic expressions simplification', async () => {
+  // first test that automatic simplification is on by default
+  await page.setLatex(0, String.raw`-F-F_{B}-F_{W}-\frac{F\cdot l_4-F_{B}\cdot l_2+F_{W}\cdot l_3}{l_1+l_2}+\frac{F\cdot l_1+F\cdot l_2+F\cdot l_4+F_{B}\cdot l_1+F_{W}\cdot l_1+F_{W}\cdot l_2+F_{W}\cdot l_3}{l_1+l_2}\ =`);
+
+  await page.waitForSelector('.status-footer', { state: 'detached'});
+
+  // check query result in cell 1
+  let content = await page.textContent('#result-value-0');
+  expect(content).toBe('0');
+
+  // turn off automatic simplification
+  await page.getByRole('button', { name: 'Sheet Settings' }).click();
+  await page.locator('label').filter({ hasText: 'Automatically Simplify Symbolic Expressions' }).click();
+  await page.getByRole('button', { name: 'Confirm' }).click();
+
+  // check query result in cell 1
+  content = await page.textContent('#result-value-0');
+  expect(content).toBe(String.raw`- F - F_{B} - F_{W} - \frac{F l_{4} - F_{B} l_{2} + F_{W} l_{3}}{l_{1} + l_{2}} + \frac{F l_{1} + F l_{2} + F l_{4} + F_{B} l_{1} + F_{W} l_{1} + F_{W} l_{2} + F_{W} l_{3}}{l_{1} + l_{2}}`);
+
+});
 
 test('Test auto exponent', async () => {
   await page.setLatex(0, String.raw`\frac{2}{3}=`);

--- a/tests/test_number_format.spec.mjs
+++ b/tests/test_number_format.spec.mjs
@@ -104,6 +104,8 @@ test('Test disabling automatic expressions simplification', async () => {
   await page.locator('label').filter({ hasText: 'Automatically Simplify Symbolic Expressions' }).click();
   await page.getByRole('button', { name: 'Confirm' }).click();
 
+  await page.waitForSelector('.status-footer', { state: 'detached'});
+
   // check query result in cell 1
   content = await page.textContent('#result-value-0');
   expect(content).toBe(String.raw`- F - F_{B} - F_{W} - \frac{F l_{4} - F_{B} l_{2} + F_{W} l_{3}}{l_{1} + l_{2}} + \frac{F l_{1} + F l_{2} + F l_{4} + F_{B} l_{1} + F_{W} l_{1} + F_{W} l_{2} + F_{W} l_{3}}{l_{1} + l_{2}}`);


### PR DESCRIPTION
Disabling symbolic expression simplification can speed up calculations for sheets with complex expressions. Does not impact numeric results.
