### PR TITLE
feat: save as

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -90,7 +90,7 @@
 
   const apiUrl = window.location.origin;
 
-  const currentVersion = 20240226;
+  const currentVersion = 20240227;
   const tutorialHash = "fFjTsnFoSQMLwcvteVoNtL";
 
   const termsVersion = 20240110;
@@ -554,16 +554,24 @@
           loadBlankSheet();
         }
         break;
-      case "s":
-      case "S":
+      case "l":
+      case "L":
         if (!event[$modifierKey] || modalInfo.modalOpen) {
           return;
-        } else if (event.shiftKey) {
+        } else {
           modalInfo = {
             state: "uploadSheet",
             modalOpen: true,
             heading: "Save as Sharable Link"
           };
+        }
+        break;
+      case "s":
+      case "S":
+        if (!event[$modifierKey] || modalInfo.modalOpen) {
+          return;
+        } else if (event.shiftKey) {
+          saveSheetToFile(true);
         } else {
           saveSheetToFile();
         }
@@ -1515,7 +1523,7 @@ Please include a link to this sheet in the email to assist in debugging the prob
 
   // Save using a download anchor element
   // Will be saved to users downloads folder
-  async function saveSheetToFile() {
+  async function saveSheetToFile(saveAs = false) {
     $history = [{
       url: $title,
       hash: 'file',
@@ -1536,7 +1544,7 @@ Please include a link to this sheet in the email to assist in debugging the prob
 
       // use current file handle if user has already saved this sheet
       const currentFileHandle = getFileHandleFromKey(window.history.state?.fileKey);
-      if (currentFileHandle && window.history.state?.fileKey ===  currentFileHandle.name + $title + $sheetId) {
+      if (!saveAs && currentFileHandle && window.history.state?.fileKey ===  currentFileHandle.name + $title + $sheetId) {
         modalInfo = {state: "saving", modalOpen: true, heading: "Saving File"};
         try {
           const writable = await currentFileHandle.createWritable();
@@ -2679,7 +2687,7 @@ Please include a link to this sheet in the email to assist in debugging the prob
     {:else if modalInfo.state === "downloadDocument"}
       <DownloadDocumentModal
         bind:open={modalInfo.modalOpen}
-        on:downloadSheet={saveSheetToFile}
+        on:downloadSheet={(e) => saveSheetToFile(e.detail.saveAs)}
         on:downloadDocument={(e) => getDocument(e.detail.docType, e.detail.getShareableLink)}
       />
     {:else}

--- a/src/DownloadDocumentModal.svelte
+++ b/src/DownloadDocumentModal.svelte
@@ -6,16 +6,17 @@
 
   const dispatch = createEventDispatcher<{
     downloadDocument: {docType: "docx" | "pdf" | "md" | "tex", getShareableLink: boolean};
-    downloadSheet: null;
+    downloadSheet: {saveAs: boolean};
   }>();
 
   let docType: "epxyz" | "docx" | "pdf" | "md" | "tex" = "epxyz";
   let getShareableLink = false;
+  let saveAs = false;
 
   async function handleSave() {
     open = false;
     if (docType === "epxyz") {
-      dispatch("downloadSheet");
+      dispatch("downloadSheet", {saveAs: saveAs});
     } else {
       dispatch("downloadDocument", {docType: docType, getShareableLink: getShareableLink});
     }
@@ -52,12 +53,22 @@
       required={true}
       bind:selected={docType}
     >
-      <RadioButton labelText="Native EngineeringPaper.xyz .epxyz Sheet File (no data leaves your computer)" value="epxyz" />
+      <RadioButton labelText="Native EngineeringPaper.xyz .epxyz Sheet File (no data leaves your computer)" value="epxyz"/>
       <RadioButton labelText="Markdown File (no data leaves your computer)" value="md" />
       <RadioButton labelText="Microsoft Word .docx File (processed on the EngineeringPaper.xyz server, no data is retained on the server)" value="docx" />
       <RadioButton labelText="PDF File (processed on the EngineeringPaper.xyz server, no data is retained on the server)" value="pdf" />
       <RadioButton labelText="LaTeX File (images and plots are not included, processed on the EngineeringPaper.xyz server, no data is retained on the server)" value="tex" />
     </RadioButtonGroup>
+    {#if window.showSaveFilePicker}
+      <div>
+        <div class="bx--label">Save As</div>
+        <Checkbox 
+          labelText="Prompt to change file name"
+          bind:checked={saveAs}
+          disabled={docType !== "epxyz"}
+        />
+      </div>
+    {/if}
     <div>
       <div class="bx--label">Shareable Link</div>
       <Checkbox 

--- a/src/KeyboardShortcuts.svelte
+++ b/src/KeyboardShortcuts.svelte
@@ -108,6 +108,10 @@
     </tr>
     <tr>
       <td class="first-column"><span class="key">{modifier}</span> + <span class="key">Shift</span> + <span class="key">S</span></td>
+      <td>Save current sheet to local file with a new filename instead of replacing existing file </td>
+    </tr>
+    <tr>
+      <td class="first-column"><span class="key">{modifier}</span> + <span class="key">L</span></td>
       <td>Save current sheet to database to get a shareable link</td>
     </tr>
     <tr>

--- a/src/Updates.svelte
+++ b/src/Updates.svelte
@@ -16,6 +16,20 @@
   }
 </style>
 
+<em>February 27, 2024</em>
+<h4>Save As Shortcut Added and Shareable Link Shortcut Changed</h4>
+<p>
+   When using Chrome, or a Chrome based browser such as Edge, hitting {modifier}-S 
+   will automatically re-save the file using the same name, if it has already been 
+   saved. The {modifier}-Shift-S keyboard shortcut can now be used to perform a Save As 
+   operation to allow you to choose a different file name. Additionally, the Save Document 
+   menu now includes a Save As checkbox to serve the same purpose. The {modifier}-Shift-S 
+   keyboard shortcut was previously used to save your document as a shareable link. The 
+   {modifier}-L keyboard shortcut can now be used the create a shareable link. 
+</p>
+
+<br>
+
 <em>February 26, 2024</em>
 <h4>File Saving Improvements</h4>
 <p>


### PR DESCRIPTION
Add save as functionality (only impacts chrome based browsers). Additionally, change create shareable link shortcut to Ctrl-L (or Cmd-L on Mac).