### PR TITLE
feat: add automatic decimal to fraction conversion sheet setting

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -840,7 +840,8 @@
       statements: statements,
       systemDefinitions: systemDefinitions, 
       customBaseUnits: $config.customBaseUnits,
-      simplifySymbolicExpressions: $config.simplifySymbolicExpressions
+      simplifySymbolicExpressions: $config.simplifySymbolicExpressions,
+      convertFloatsToFractions: $config.convertFloatsToFractions
     };
   }
 
@@ -1103,6 +1104,7 @@ Please include a link to this sheet in the email to assist in debugging the prob
       $config = sheet.config ?? getDefaultConfig();
       $config.customBaseUnits = $config.customBaseUnits ?? getDefaultBaseUnits(); // customBaseUnits may not exist
       $config.simplifySymbolicExpressions = $config.simplifySymbolicExpressions ?? true; // simplifySymboicExpressions may not exist
+      $config.convertFloatsToFractions = $config.convertFloatsToFractions ?? true; // convertFloatsToFractions may not exist
     
       if (!$history.map(item => item.hash !== "file" ? getSheetHash(new URL(item.url)) : "").includes(getSheetHash(window.location))) {
         $history = requestHistory;
@@ -2644,7 +2646,8 @@ Please include a link to this sheet in the email to assist in debugging the prob
         on:click:button--primary={() => modalInfo.modalOpen = false}
         on:click:button--secondary={() => {mathCellConfigDialog?.resetDefaults();
                                            baseUnitsConfigDialog?.resetDefaults();
-                                           $config.simplifySymbolicExpressions = true;}}
+                                           $config.simplifySymbolicExpressions = true;
+                                           $config.convertFloatsToFractions = true;}}
         bind:open={modalInfo.modalOpen}
       >
         {#if modalInfo.mathCell}
@@ -2661,8 +2664,13 @@ Please include a link to this sheet in the email to assist in debugging the prob
             <svelte:fragment slot="content">
               <TabContent>
                 <Checkbox 
-                  labelText="Automatically Simplify Symbolic Expressions (unchecking will speed up sheet updates)"
+                  labelText="Automatically Simplify Symbolic Expressions (unchecking may speed up sheet updates)"
                   bind:checked={$config.simplifySymbolicExpressions}
+                  on:check={() => $mathCellChanged = true}
+                />
+                <Checkbox 
+                  labelText="Automatically Convert Decimal Values to Fractions (increases precision for decimal numbers, unchecking may speed up sheet updates)"
+                  bind:checked={$config.convertFloatsToFractions}
                   on:check={() => $mathCellChanged = true}
                 />
                 <MathCellConfigDialog

--- a/src/sheet/Sheet.ts
+++ b/src/sheet/Sheet.ts
@@ -23,6 +23,7 @@ export type Config = {
   mathCellConfig: MathCellConfig;
   customBaseUnits?: CustomBaseUnits; // some early sheets won't have this property
   simplifySymbolicExpressions?: boolean; // some early sheets won't have this property
+  convertFloatsToFractions?: boolean; // some early sheets won't have this property
 };
 
 type Notation = "auto" | "fixed" | "exponential" | "engineering";
@@ -43,7 +44,8 @@ export function getDefaultConfig(): Config {
   return {
     mathCellConfig: getDefaultMathCellConfig(),
     customBaseUnits: getDefaultBaseUnits(),
-    simplifySymbolicExpressions: true
+    simplifySymbolicExpressions: true,
+    convertFloatsToFractions: true
   };
 }
 
@@ -82,7 +84,8 @@ export function isDefaultMathConfig(config: MathCellConfig): boolean {
 export function isDefaultConfig(config: Config): boolean {
   return isDefaultMathConfig(config.mathCellConfig) && 
          isDefaultBaseUnits(config.customBaseUnits) &&
-         config.simplifySymbolicExpressions === true;
+         config.simplifySymbolicExpressions === true && 
+         config.convertFloatsToFractions === true;
 }
 
 export function copyMathConfig(input: MathCellConfig): MathCellConfig {

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -22,7 +22,7 @@ const defaultTitle = 'New Sheet';
 export const unsavedChange = writable(false);
 export const autosaveNeeded = writable(false);
 
-export const config = writable(getDefaultConfig())
+export const config = writable(getDefaultConfig());
 export const cells: Writable<Cell[]> = writable([]);
 export const title = writable(defaultTitle);
 export const results: Writable<(Result | FiniteImagResult | MatrixResult | PlotResult[])[]> = writable([]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export type StatementsAndSystems = {
   systemDefinitions: SystemDefinition[];
   customBaseUnits?: CustomBaseUnits;
   simplifySymbolicExpressions: boolean;
+  convertFloatsToFractions: boolean;
 }
 
 

--- a/tests/test_number_format.spec.mjs
+++ b/tests/test_number_format.spec.mjs
@@ -515,3 +515,35 @@ test('Test number input validation', async () => {
   expect(content).toBe('0.666666666666667');
 
 });
+
+
+test('Test disabling automatic fraction conversion', async () => {
+  // turn off automatic simplification
+  await page.getByRole('button', { name: 'Sheet Settings' }).click();
+  await page.locator('label').filter({ hasText: 'Automatically Convert Decimal Values to Fractions' }).click();
+  await page.getByRole('button', { name: 'Confirm' }).click();
+  
+  await page.setLatex(0, String.raw`\left(\frac{1.115625000065330001000001000010001}{1.355801000010000100001000010000100010}\right)^{\frac{1}{-.01780001000100010001}}=`);
+
+  await page.waitForSelector('text=Updating...', {state: 'detached'});
+
+  // check output
+  let content = await page.textContent('#result-value-0');
+  expect(parseLatexFloat(content)).toBeCloseTo(57170.5227437832, precision);
+});
+
+
+test('Test default automatic fraction conversion setting', async () => {
+  await page.setLatex(0, String.raw`.125=`);
+
+  // turn on symbolic results 
+  await page.getByRole('button', { name: 'Sheet Settings' }).click();
+  await page.locator('label').filter({ hasText: 'Display Symbolic Results' }).click();
+  await page.getByRole('button', { name: 'Confirm' }).click();
+
+  await page.waitForSelector('text=Updating...', {state: 'detached'});
+
+  // check output
+  let content = await page.textContent('#result-value-0');
+  expect(content).toBe(String.raw`\frac{1}{8}`);
+});


### PR DESCRIPTION
This has been the default but there are cases where sheets may fail to solve because of the excessive length of some of the rational representations. When these situations occur, the error messages have been updated to recommend changing this setting to solve the issues.
