### PR TITLE
fix: patch mathlive scroll into focus logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "idb-keyval": "^6.2.0",
         "mathjax": "^3.2.2",
         "mathjs": "^11.8.2",
-        "mathlive": "github:mgreminger/mathlive#bbe2b44a1f84f4107784a2f92beda30bc62411f1",
+        "mathlive": "github:mgreminger/mathlive#2398c671d7d66871f9d76333d76d29ff530ce733",
         "plotly.js-basic-dist": "github:mgreminger/plotly.js#dist-basic-for-ep",
         "quick-lru": "^6.1.1",
         "quill": "^1.3.7",
@@ -5270,9 +5270,8 @@
     },
     "node_modules/mathlive": {
       "version": "0.98.6",
-      "resolved": "git+ssh://git@github.com/mgreminger/mathlive.git#bbe2b44a1f84f4107784a2f92beda30bc62411f1",
-      "integrity": "sha512-6frGRbwga8Q6/HLf9tGUQtUBwwzifTB1B/4TbAy2ahzUI26MMsQMunldVPcOaF6sc2GMhP4lVzSU0T72IEa7aQ==",
-      "license": "MIT",
+      "resolved": "git+ssh://git@github.com/mgreminger/mathlive.git#2398c671d7d66871f9d76333d76d29ff530ce733",
+      "integrity": "sha512-Fr6nH8byhuWONunOgD58A9kpFZWnNtbNYguJwbds77TGf0U40hJ3EQRJszfFTxADIyTIrarfJBZ9+5t6hG5drw==",
       "dependencies": {
         "@cortex-js/compute-engine": "0.23.1"
       },
@@ -11732,9 +11731,9 @@
       }
     },
     "mathlive": {
-      "version": "git+ssh://git@github.com/mgreminger/mathlive.git#bbe2b44a1f84f4107784a2f92beda30bc62411f1",
-      "integrity": "sha512-6frGRbwga8Q6/HLf9tGUQtUBwwzifTB1B/4TbAy2ahzUI26MMsQMunldVPcOaF6sc2GMhP4lVzSU0T72IEa7aQ==",
-      "from": "mathlive@github:mgreminger/mathlive#bbe2b44a1f84f4107784a2f92beda30bc62411f1",
+      "version": "git+ssh://git@github.com/mgreminger/mathlive.git#2398c671d7d66871f9d76333d76d29ff530ce733",
+      "integrity": "sha512-Fr6nH8byhuWONunOgD58A9kpFZWnNtbNYguJwbds77TGf0U40hJ3EQRJszfFTxADIyTIrarfJBZ9+5t6hG5drw==",
+      "from": "mathlive@github:mgreminger/mathlive#2398c671d7d66871f9d76333d76d29ff530ce733",
       "requires": {
         "@cortex-js/compute-engine": "0.23.1"
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "idb-keyval": "^6.2.0",
     "mathjax": "^3.2.2",
     "mathjs": "^11.8.2",
-    "mathlive": "github:mgreminger/mathlive#bbe2b44a1f84f4107784a2f92beda30bc62411f1",
+    "mathlive": "github:mgreminger/mathlive#2398c671d7d66871f9d76333d76d29ff530ce733",
     "plotly.js-basic-dist": "github:mgreminger/plotly.js#dist-basic-for-ep",
     "quick-lru": "^6.1.1",
     "quill": "^1.3.7",


### PR DESCRIPTION
The current logic does not work for mathlive field in scrollable element and calls getBoundingClientRect and every edit, which is slow
