### PR TITLE
fix: return focus to mathfield when returning to tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "idb-keyval": "^6.2.0",
         "mathjax": "^3.2.2",
         "mathjs": "^11.8.2",
-        "mathlive": "github:mgreminger/mathlive#2398c671d7d66871f9d76333d76d29ff530ce733",
+        "mathlive": "github:mgreminger/mathlive#05347383c43787feafba5bb48f51b3e3389ed641",
         "plotly.js-basic-dist": "github:mgreminger/plotly.js#dist-basic-for-ep",
         "quick-lru": "^6.1.1",
         "quill": "^1.3.7",
@@ -5271,8 +5271,8 @@
     },
     "node_modules/mathlive": {
       "version": "0.98.6",
-      "resolved": "git+ssh://git@github.com/mgreminger/mathlive.git#2398c671d7d66871f9d76333d76d29ff530ce733",
-      "integrity": "sha512-Fr6nH8byhuWONunOgD58A9kpFZWnNtbNYguJwbds77TGf0U40hJ3EQRJszfFTxADIyTIrarfJBZ9+5t6hG5drw==",
+      "resolved": "git+ssh://git@github.com/mgreminger/mathlive.git#05347383c43787feafba5bb48f51b3e3389ed641",
+      "integrity": "sha512-U02Fy3n/vwrit4KvlUPry5ZiVwGwsY/LzmJvFqS/9VrXxeUwtjt3aJWUubU3l0H8/q8GQ6gqtP9AX3imeyskRg==",
       "dependencies": {
         "@cortex-js/compute-engine": "0.23.1"
       },
@@ -11743,9 +11743,9 @@
       }
     },
     "mathlive": {
-      "version": "git+ssh://git@github.com/mgreminger/mathlive.git#2398c671d7d66871f9d76333d76d29ff530ce733",
-      "integrity": "sha512-Fr6nH8byhuWONunOgD58A9kpFZWnNtbNYguJwbds77TGf0U40hJ3EQRJszfFTxADIyTIrarfJBZ9+5t6hG5drw==",
-      "from": "mathlive@github:mgreminger/mathlive#2398c671d7d66871f9d76333d76d29ff530ce733",
+      "version": "git+ssh://git@github.com/mgreminger/mathlive.git#05347383c43787feafba5bb48f51b3e3389ed641",
+      "integrity": "sha512-U02Fy3n/vwrit4KvlUPry5ZiVwGwsY/LzmJvFqS/9VrXxeUwtjt3aJWUubU3l0H8/q8GQ6gqtP9AX3imeyskRg==",
+      "from": "mathlive@github:mgreminger/mathlive#05347383c43787feafba5bb48f51b3e3389ed641",
       "requires": {
         "@cortex-js/compute-engine": "0.23.1"
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "idb-keyval": "^6.2.0",
     "mathjax": "^3.2.2",
     "mathjs": "^11.8.2",
-    "mathlive": "github:mgreminger/mathlive#2398c671d7d66871f9d76333d76d29ff530ce733",
+    "mathlive": "github:mgreminger/mathlive#05347383c43787feafba5bb48f51b3e3389ed641",
     "plotly.js-basic-dist": "github:mgreminger/plotly.js#dist-basic-for-ep",
     "quick-lru": "^6.1.1",
     "quill": "^1.3.7",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -620,6 +620,7 @@
         modalInfo.modalOpen = false;
         sideNavOpen = false;
         fileDropActive = false;
+        document.body.click();
         break;
       case "Enter":
         if ($activeCell < 0 && event.shiftKey && !modalInfo.modalOpen) {


### PR DESCRIPTION
Worked before only if switching tabs, now works when switching windows and both are visible.

Also, escape simulates body click to force refocusing to cancel as expected.
