### PR TITLE
fix: handle case of unintended operator font separated by equals sign

### DIFF
--- a/src/parser/LatexParser.g4
+++ b/src/parser/LatexParser.g4
@@ -126,7 +126,7 @@ expr: <assoc=right> id CARET_SINGLE_CHAR_ID_UNDERSCORE_SUBSCRIPT            #exp
     | expr derivative_cmd                                                   #missingMultiplication
     | expr n_derivative_cmd                                                 #missingMultiplication
     | CMD_PLACEHOLDER (L_BRACE R_BRACE)?                                    #emptyPlaceholder
-    | (CMD_MATHRM L_BRACE expr R_BRACE)? (DECIMAL_POINT | number)? CMD_MATHRM L_BRACE expr R_BRACE (DECIMAL_POINT | number)? #removeOperatorFont
+    | (CMD_MATHRM L_BRACE expr R_BRACE)? (DECIMAL_POINT | number | EQ)? CMD_MATHRM L_BRACE expr R_BRACE (DECIMAL_POINT | number | EQ)? #removeOperatorFont
     ;
 
 

--- a/src/parser/LatexParser.ts
+++ b/src/parser/LatexParser.ts
@@ -2132,7 +2132,7 @@ export default class LatexParser extends Parser {
 			let _alt: number;
 			this.enterOuterAlt(localctx, 1);
 			{
-			this.state = 576;
+			this.state = 578;
 			this._errHandler.sync(this);
 			switch ( this._interp.adaptivePredict(this._input, 45, this._ctx) ) {
 			case 1:
@@ -2586,7 +2586,7 @@ export default class LatexParser extends Parser {
 					}
 					break;
 				}
-				this.state = 566;
+				this.state = 567;
 				this._errHandler.sync(this);
 				switch (this._input.LA(1)) {
 				case 60:
@@ -2602,32 +2602,44 @@ export default class LatexParser extends Parser {
 					this.number_();
 					}
 					break;
+				case 54:
+					{
+					this.state = 566;
+					this.match(LatexParser.EQ);
+					}
+					break;
 				case 16:
 					break;
 				default:
 					break;
 				}
-				this.state = 568;
-				this.match(LatexParser.CMD_MATHRM);
 				this.state = 569;
-				this.match(LatexParser.L_BRACE);
+				this.match(LatexParser.CMD_MATHRM);
 				this.state = 570;
-				this.expr(0);
+				this.match(LatexParser.L_BRACE);
 				this.state = 571;
+				this.expr(0);
+				this.state = 572;
 				this.match(LatexParser.R_BRACE);
-				this.state = 574;
+				this.state = 576;
 				this._errHandler.sync(this);
 				switch ( this._interp.adaptivePredict(this._input, 44, this._ctx) ) {
 				case 1:
 					{
-					this.state = 572;
+					this.state = 573;
 					this.match(LatexParser.DECIMAL_POINT);
 					}
 					break;
 				case 2:
 					{
-					this.state = 573;
+					this.state = 574;
 					this.number_();
+					}
+					break;
+				case 3:
+					{
+					this.state = 575;
+					this.match(LatexParser.EQ);
 					}
 					break;
 				}
@@ -2635,7 +2647,7 @@ export default class LatexParser extends Parser {
 				break;
 			}
 			this._ctx.stop = this._input.LT(-1);
-			this.state = 640;
+			this.state = 642;
 			this._errHandler.sync(this);
 			_alt = this._interp.adaptivePredict(this._input, 47, this._ctx);
 			while (_alt !== 2 && _alt !== ATN.INVALID_ALT_NUMBER) {
@@ -2645,20 +2657,20 @@ export default class LatexParser extends Parser {
 					}
 					_prevctx = localctx;
 					{
-					this.state = 638;
+					this.state = 640;
 					this._errHandler.sync(this);
 					switch ( this._interp.adaptivePredict(this._input, 46, this._ctx) ) {
 					case 1:
 						{
 						localctx = new MatrixMultiplyContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 578;
+						this.state = 580;
 						if (!(this.precpred(this._ctx, 29))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 29)");
 						}
-						this.state = 579;
+						this.state = 581;
 						this.match(LatexParser.CMD_TIMES);
-						this.state = 580;
+						this.state = 582;
 						this.expr(30);
 						}
 						break;
@@ -2666,13 +2678,13 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new MultiplyContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 581;
+						this.state = 583;
 						if (!(this.precpred(this._ctx, 28))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 28)");
 						}
-						this.state = 582;
+						this.state = 584;
 						this.match(LatexParser.CMD_CDOT);
-						this.state = 583;
+						this.state = 585;
 						this.expr(29);
 						}
 						break;
@@ -2680,13 +2692,13 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new SubtractContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 584;
+						this.state = 586;
 						if (!(this.precpred(this._ctx, 25))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 25)");
 						}
-						this.state = 585;
+						this.state = 587;
 						this.match(LatexParser.SUB);
-						this.state = 586;
+						this.state = 588;
 						this.expr(26);
 						}
 						break;
@@ -2694,13 +2706,13 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new AddContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 587;
+						this.state = 589;
 						if (!(this.precpred(this._ctx, 24))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 24)");
 						}
-						this.state = 588;
+						this.state = 590;
 						this.match(LatexParser.ADD);
-						this.state = 589;
+						this.state = 591;
 						this.expr(25);
 						}
 						break;
@@ -2708,11 +2720,11 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new ExponentContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 590;
+						this.state = 592;
 						if (!(this.precpred(this._ctx, 50))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 50)");
 						}
-						this.state = 591;
+						this.state = 593;
 						_la = this._input.LA(1);
 						if(!(_la===61 || _la===62)) {
 						this._errHandler.recoverInline(this);
@@ -2727,17 +2739,17 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new ExponentContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 592;
+						this.state = 594;
 						if (!(this.precpred(this._ctx, 49))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 49)");
 						}
-						this.state = 593;
-						this.match(LatexParser.CARET);
-						this.state = 594;
-						this.match(LatexParser.L_BRACE);
 						this.state = 595;
-						this.expr(0);
+						this.match(LatexParser.CARET);
 						this.state = 596;
+						this.match(LatexParser.L_BRACE);
+						this.state = 597;
+						this.expr(0);
+						this.state = 598;
 						this.match(LatexParser.R_BRACE);
 						}
 						break;
@@ -2745,21 +2757,21 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new IndexContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 598;
+						this.state = 600;
 						if (!(this.precpred(this._ctx, 48))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 48)");
 						}
-						this.state = 599;
-						this.match(LatexParser.UNDERSCORE);
-						this.state = 600;
-						this.match(LatexParser.L_BRACE);
 						this.state = 601;
-						this.expr(0);
+						this.match(LatexParser.UNDERSCORE);
 						this.state = 602;
-						this.match(LatexParser.COMMA);
+						this.match(LatexParser.L_BRACE);
 						this.state = 603;
 						this.expr(0);
 						this.state = 604;
+						this.match(LatexParser.COMMA);
+						this.state = 605;
+						this.expr(0);
+						this.state = 606;
 						this.match(LatexParser.R_BRACE);
 						}
 						break;
@@ -2767,11 +2779,11 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new TransposeContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 606;
+						this.state = 608;
 						if (!(this.precpred(this._ctx, 47))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 47)");
 						}
-						this.state = 607;
+						this.state = 609;
 						this.match(LatexParser.TRANSPOSE);
 						}
 						break;
@@ -2779,15 +2791,15 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new EmptySubscriptContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 608;
+						this.state = 610;
 						if (!(this.precpred(this._ctx, 18))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 18)");
 						}
-						this.state = 609;
-						this.match(LatexParser.UNDERSCORE);
-						this.state = 610;
-						this.match(LatexParser.L_BRACE);
 						this.state = 611;
+						this.match(LatexParser.UNDERSCORE);
+						this.state = 612;
+						this.match(LatexParser.L_BRACE);
+						this.state = 613;
 						this.match(LatexParser.R_BRACE);
 						}
 						break;
@@ -2795,15 +2807,15 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new EmptySuperscriptContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 612;
+						this.state = 614;
 						if (!(this.precpred(this._ctx, 17))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 17)");
 						}
-						this.state = 613;
-						this.match(LatexParser.CARET);
-						this.state = 614;
-						this.match(LatexParser.L_BRACE);
 						this.state = 615;
+						this.match(LatexParser.CARET);
+						this.state = 616;
+						this.match(LatexParser.L_BRACE);
+						this.state = 617;
 						this.match(LatexParser.R_BRACE);
 						}
 						break;
@@ -2811,11 +2823,11 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new MissingMultiplicationContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 616;
+						this.state = 618;
 						if (!(this.precpred(this._ctx, 16))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 16)");
 						}
-						this.state = 617;
+						this.state = 619;
 						this.id();
 						}
 						break;
@@ -2823,11 +2835,11 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new MissingMultiplicationContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 618;
+						this.state = 620;
 						if (!(this.precpred(this._ctx, 15))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 15)");
 						}
-						this.state = 619;
+						this.state = 621;
 						this.number_();
 						}
 						break;
@@ -2835,11 +2847,11 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new MissingMultiplicationContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 620;
+						this.state = 622;
 						if (!(this.precpred(this._ctx, 14))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 14)");
 						}
-						this.state = 621;
+						this.state = 623;
 						this.number_with_units();
 						}
 						break;
@@ -2847,11 +2859,11 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new MissingMultiplicationContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 622;
+						this.state = 624;
 						if (!(this.precpred(this._ctx, 13))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 13)");
 						}
-						this.state = 623;
+						this.state = 625;
 						this.match(LatexParser.PI);
 						}
 						break;
@@ -2859,11 +2871,11 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new MissingMultiplicationContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 624;
+						this.state = 626;
 						if (!(this.precpred(this._ctx, 9))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 9)");
 						}
-						this.state = 625;
+						this.state = 627;
 						this.user_function();
 						}
 						break;
@@ -2871,11 +2883,11 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new MissingMultiplicationContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 626;
+						this.state = 628;
 						if (!(this.precpred(this._ctx, 8))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 8)");
 						}
-						this.state = 627;
+						this.state = 629;
 						this.builtin_function();
 						}
 						break;
@@ -2883,11 +2895,11 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new MissingMultiplicationContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 628;
+						this.state = 630;
 						if (!(this.precpred(this._ctx, 7))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 7)");
 						}
-						this.state = 629;
+						this.state = 631;
 						this.trig_function();
 						}
 						break;
@@ -2895,11 +2907,11 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new MissingMultiplicationContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 630;
+						this.state = 632;
 						if (!(this.precpred(this._ctx, 6))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 6)");
 						}
-						this.state = 631;
+						this.state = 633;
 						this.indefinite_integral_cmd();
 						}
 						break;
@@ -2907,11 +2919,11 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new MissingMultiplicationContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 632;
+						this.state = 634;
 						if (!(this.precpred(this._ctx, 5))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 5)");
 						}
-						this.state = 633;
+						this.state = 635;
 						this.integral_cmd();
 						}
 						break;
@@ -2919,11 +2931,11 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new MissingMultiplicationContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 634;
+						this.state = 636;
 						if (!(this.precpred(this._ctx, 4))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 4)");
 						}
-						this.state = 635;
+						this.state = 637;
 						this.derivative_cmd();
 						}
 						break;
@@ -2931,18 +2943,18 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new MissingMultiplicationContext(this, new ExprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_expr);
-						this.state = 636;
+						this.state = 638;
 						if (!(this.precpred(this._ctx, 3))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 3)");
 						}
-						this.state = 637;
+						this.state = 639;
 						this.n_derivative_cmd();
 						}
 						break;
 					}
 					}
 				}
-				this.state = 642;
+				this.state = 644;
 				this._errHandler.sync(this);
 				_alt = this._interp.adaptivePredict(this._input, 47, this._ctx);
 			}
@@ -2970,7 +2982,7 @@ export default class LatexParser extends Parser {
 		try {
 			this.enterOuterAlt(localctx, 1);
 			{
-			this.state = 643;
+			this.state = 645;
 			_la = this._input.LA(1);
 			if(!(_la===1 || _la===2)) {
 			this._errHandler.recoverInline(this);
@@ -2979,9 +2991,9 @@ export default class LatexParser extends Parser {
 				this._errHandler.reportMatch(this);
 			    this.consume();
 			}
-			this.state = 644;
+			this.state = 646;
 			this.u_expr(0);
-			this.state = 645;
+			this.state = 647;
 			_la = this._input.LA(1);
 			if(!(_la===76 || _la===77)) {
 			this._errHandler.recoverInline(this);
@@ -3014,7 +3026,7 @@ export default class LatexParser extends Parser {
 		try {
 			this.enterOuterAlt(localctx, 1);
 			{
-			this.state = 647;
+			this.state = 649;
 			_la = this._input.LA(1);
 			if(!(_la===1 || _la===2)) {
 			this._errHandler.recoverInline(this);
@@ -3023,7 +3035,7 @@ export default class LatexParser extends Parser {
 				this._errHandler.reportMatch(this);
 			    this.consume();
 			}
-			this.state = 648;
+			this.state = 650;
 			localctx._numRows = this._input.LT(1);
 			_la = this._input.LA(1);
 			if(!(_la===90 || _la===91)) {
@@ -3033,7 +3045,7 @@ export default class LatexParser extends Parser {
 				this._errHandler.reportMatch(this);
 			    this.consume();
 			}
-			this.state = 649;
+			this.state = 651;
 			_la = this._input.LA(1);
 			if(!(_la===81 || _la===83)) {
 			this._errHandler.recoverInline(this);
@@ -3042,7 +3054,7 @@ export default class LatexParser extends Parser {
 				this._errHandler.reportMatch(this);
 			    this.consume();
 			}
-			this.state = 650;
+			this.state = 652;
 			localctx._numColumns = this._input.LT(1);
 			_la = this._input.LA(1);
 			if(!(_la===90 || _la===91)) {
@@ -3052,7 +3064,7 @@ export default class LatexParser extends Parser {
 				this._errHandler.reportMatch(this);
 			    this.consume();
 			}
-			this.state = 651;
+			this.state = 653;
 			_la = this._input.LA(1);
 			if(!(_la===76 || _la===77)) {
 			this._errHandler.recoverInline(this);
@@ -3083,17 +3095,17 @@ export default class LatexParser extends Parser {
 		this.enterRule(localctx, 64, LatexParser.RULE_u_fraction);
 		let _la: number;
 		try {
-			this.state = 661;
+			this.state = 663;
 			this._errHandler.sync(this);
 			switch (this._input.LA(1)) {
 			case 78:
 				this.enterOuterAlt(localctx, 1);
 				{
-				this.state = 653;
-				this.match(LatexParser.U_CMD_FRAC);
-				this.state = 654;
-				this.match(LatexParser.U_L_BRACE);
 				this.state = 655;
+				this.match(LatexParser.U_CMD_FRAC);
+				this.state = 656;
+				this.match(LatexParser.U_L_BRACE);
+				this.state = 657;
 				_la = this._input.LA(1);
 				if(!(_la===90 || _la===91)) {
 				this._errHandler.recoverInline(this);
@@ -3102,20 +3114,20 @@ export default class LatexParser extends Parser {
 					this._errHandler.reportMatch(this);
 				    this.consume();
 				}
-				this.state = 656;
-				this.match(LatexParser.U_R_BRACE);
-				this.state = 657;
-				this.match(LatexParser.U_L_BRACE);
 				this.state = 658;
-				this.match(LatexParser.U_NUMBER);
+				this.match(LatexParser.U_R_BRACE);
 				this.state = 659;
+				this.match(LatexParser.U_L_BRACE);
+				this.state = 660;
+				this.match(LatexParser.U_NUMBER);
+				this.state = 661;
 				this.match(LatexParser.U_R_BRACE);
 				}
 				break;
 			case 79:
 				this.enterOuterAlt(localctx, 2);
 				{
-				this.state = 660;
+				this.state = 662;
 				this.match(LatexParser.U_CMD_FRAC_INTS);
 				}
 				break;
@@ -3156,7 +3168,7 @@ export default class LatexParser extends Parser {
 			let _alt: number;
 			this.enterOuterAlt(localctx, 1);
 			{
-			this.state = 685;
+			this.state = 687;
 			this._errHandler.sync(this);
 			switch (this._input.LA(1)) {
 			case 82:
@@ -3165,13 +3177,13 @@ export default class LatexParser extends Parser {
 				this._ctx = localctx;
 				_prevctx = localctx;
 
-				this.state = 664;
-				this.match(LatexParser.U_CMD_SQRT);
-				this.state = 665;
-				this.match(LatexParser.U_L_BRACE);
 				this.state = 666;
-				this.expr(0);
+				this.match(LatexParser.U_CMD_SQRT);
 				this.state = 667;
+				this.match(LatexParser.U_L_BRACE);
+				this.state = 668;
+				this.expr(0);
+				this.state = 669;
 				this.match(LatexParser.U_R_BRACE);
 				}
 				break;
@@ -3180,11 +3192,11 @@ export default class LatexParser extends Parser {
 				localctx = new UnitDivideContext(this, localctx);
 				this._ctx = localctx;
 				_prevctx = localctx;
-				this.state = 669;
+				this.state = 671;
 				this.match(LatexParser.U_CMD_FRAC);
-				this.state = 670;
+				this.state = 672;
 				this.match(LatexParser.U_L_BRACE);
-				this.state = 673;
+				this.state = 675;
 				this._errHandler.sync(this);
 				switch (this._input.LA(1)) {
 				case 78:
@@ -3192,26 +3204,26 @@ export default class LatexParser extends Parser {
 				case 85:
 				case 86:
 					{
-					this.state = 671;
+					this.state = 673;
 					this.u_expr(0);
 					}
 					break;
 				case 90:
 					{
-					this.state = 672;
+					this.state = 674;
 					this.match(LatexParser.U_ONE);
 					}
 					break;
 				default:
 					throw new NoViableAltException(this);
 				}
-				this.state = 675;
-				this.match(LatexParser.U_R_BRACE);
-				this.state = 676;
-				this.match(LatexParser.U_L_BRACE);
 				this.state = 677;
-				this.u_expr(0);
+				this.match(LatexParser.U_R_BRACE);
 				this.state = 678;
+				this.match(LatexParser.U_L_BRACE);
+				this.state = 679;
+				this.u_expr(0);
+				this.state = 680;
 				this.match(LatexParser.U_R_BRACE);
 				}
 				break;
@@ -3220,7 +3232,7 @@ export default class LatexParser extends Parser {
 				localctx = new UnitNameContext(this, localctx);
 				this._ctx = localctx;
 				_prevctx = localctx;
-				this.state = 680;
+				this.state = 682;
 				this.match(LatexParser.U_NAME);
 				}
 				break;
@@ -3229,11 +3241,11 @@ export default class LatexParser extends Parser {
 				localctx = new UnitSubExprContext(this, localctx);
 				this._ctx = localctx;
 				_prevctx = localctx;
-				this.state = 681;
-				this.match(LatexParser.U_L_PAREN);
-				this.state = 682;
-				this.u_expr(0);
 				this.state = 683;
+				this.match(LatexParser.U_L_PAREN);
+				this.state = 684;
+				this.u_expr(0);
+				this.state = 685;
 				this.match(LatexParser.U_R_PAREN);
 				}
 				break;
@@ -3241,7 +3253,7 @@ export default class LatexParser extends Parser {
 				throw new NoViableAltException(this);
 			}
 			this._ctx.stop = this._input.LT(-1);
-			this.state = 709;
+			this.state = 711;
 			this._errHandler.sync(this);
 			_alt = this._interp.adaptivePredict(this._input, 52, this._ctx);
 			while (_alt !== 2 && _alt !== ATN.INVALID_ALT_NUMBER) {
@@ -3251,20 +3263,20 @@ export default class LatexParser extends Parser {
 					}
 					_prevctx = localctx;
 					{
-					this.state = 707;
+					this.state = 709;
 					this._errHandler.sync(this);
 					switch ( this._interp.adaptivePredict(this._input, 51, this._ctx) ) {
 					case 1:
 						{
 						localctx = new UnitMultiplyContext(this, new U_exprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_u_expr);
-						this.state = 687;
+						this.state = 689;
 						if (!(this.precpred(this._ctx, 4))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 4)");
 						}
-						this.state = 688;
+						this.state = 690;
 						this.match(LatexParser.U_CMD_CDOT);
-						this.state = 689;
+						this.state = 691;
 						this.u_expr(5);
 						}
 						break;
@@ -3272,13 +3284,13 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new UnitExponentContext(this, new U_exprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_u_expr);
-						this.state = 690;
+						this.state = 692;
 						if (!(this.precpred(this._ctx, 9))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 9)");
 						}
-						this.state = 691;
+						this.state = 693;
 						this.match(LatexParser.U_CARET);
-						this.state = 692;
+						this.state = 694;
 						this.match(LatexParser.U_NUMBER);
 						}
 						break;
@@ -3286,17 +3298,17 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new UnitExponentContext(this, new U_exprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_u_expr);
-						this.state = 693;
+						this.state = 695;
 						if (!(this.precpred(this._ctx, 8))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 8)");
 						}
-						this.state = 694;
-						this.match(LatexParser.U_CARET);
-						this.state = 695;
-						this.match(LatexParser.U_L_BRACE);
 						this.state = 696;
-						this.match(LatexParser.U_NUMBER);
+						this.match(LatexParser.U_CARET);
 						this.state = 697;
+						this.match(LatexParser.U_L_BRACE);
+						this.state = 698;
+						this.match(LatexParser.U_NUMBER);
+						this.state = 699;
 						this.match(LatexParser.U_R_BRACE);
 						}
 						break;
@@ -3304,13 +3316,13 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new UnitFractionalExponentContext(this, new U_exprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_u_expr);
-						this.state = 698;
+						this.state = 700;
 						if (!(this.precpred(this._ctx, 7))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 7)");
 						}
-						this.state = 699;
+						this.state = 701;
 						this.match(LatexParser.U_CARET);
-						this.state = 700;
+						this.state = 702;
 						this.u_fraction();
 						}
 						break;
@@ -3318,24 +3330,24 @@ export default class LatexParser extends Parser {
 						{
 						localctx = new UnitFractionalExponentContext(this, new U_exprContext(this, _parentctx, _parentState));
 						this.pushNewRecursionContext(localctx, _startState, LatexParser.RULE_u_expr);
-						this.state = 701;
+						this.state = 703;
 						if (!(this.precpred(this._ctx, 6))) {
 							throw this.createFailedPredicateException("this.precpred(this._ctx, 6)");
 						}
-						this.state = 702;
-						this.match(LatexParser.U_CARET);
-						this.state = 703;
-						this.match(LatexParser.U_L_BRACE);
 						this.state = 704;
-						this.u_fraction();
+						this.match(LatexParser.U_CARET);
 						this.state = 705;
+						this.match(LatexParser.U_L_BRACE);
+						this.state = 706;
+						this.u_fraction();
+						this.state = 707;
 						this.match(LatexParser.U_R_BRACE);
 						}
 						break;
 					}
 					}
 				}
-				this.state = 711;
+				this.state = 713;
 				this._errHandler.sync(this);
 				_alt = this._interp.adaptivePredict(this._input, 52, this._ctx);
 			}
@@ -3428,7 +3440,7 @@ export default class LatexParser extends Parser {
 		return true;
 	}
 
-	public static readonly _serializedATN: number[] = [4,1,98,713,2,0,7,0,2,
+	public static readonly _serializedATN: number[] = [4,1,98,715,2,0,7,0,2,
 	1,7,1,2,2,7,2,2,3,7,3,2,4,7,4,2,5,7,5,2,6,7,6,2,7,7,7,2,8,7,8,2,9,7,9,2,
 	10,7,10,2,11,7,11,2,12,7,12,2,13,7,13,2,14,7,14,2,15,7,15,2,16,7,16,2,17,
 	7,17,2,18,7,18,2,19,7,19,2,20,7,20,2,21,7,21,2,22,7,22,2,23,7,23,2,24,7,
@@ -3469,206 +3481,207 @@ export default class LatexParser extends Parser {
 	1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,
 	29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,
 	1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,3,29,556,8,29,1,29,1,29,1,29,1,
-	29,1,29,3,29,563,8,29,1,29,1,29,3,29,567,8,29,1,29,1,29,1,29,1,29,1,29,
-	1,29,3,29,575,8,29,3,29,577,8,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,
+	29,1,29,3,29,563,8,29,1,29,1,29,1,29,3,29,568,8,29,1,29,1,29,1,29,1,29,
+	1,29,1,29,1,29,3,29,577,8,29,3,29,579,8,29,1,29,1,29,1,29,1,29,1,29,1,29,
 	1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,
 	29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,
 	1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,
-	29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,5,29,639,8,29,10,29,12,29,642,
-	9,29,1,30,1,30,1,30,1,30,1,31,1,31,1,31,1,31,1,31,1,31,1,32,1,32,1,32,1,
-	32,1,32,1,32,1,32,1,32,3,32,662,8,32,1,33,1,33,1,33,1,33,1,33,1,33,1,33,
-	1,33,1,33,1,33,3,33,674,8,33,1,33,1,33,1,33,1,33,1,33,1,33,1,33,1,33,1,
-	33,1,33,3,33,686,8,33,1,33,1,33,1,33,1,33,1,33,1,33,1,33,1,33,1,33,1,33,
-	1,33,1,33,1,33,1,33,1,33,1,33,1,33,1,33,1,33,1,33,5,33,708,8,33,10,33,12,
-	33,711,9,33,1,33,2,149,156,2,58,66,34,0,2,4,6,8,10,12,14,16,18,20,22,24,
-	26,28,30,32,34,36,38,40,42,44,46,48,50,52,54,56,58,60,62,64,66,0,11,1,0,
-	29,41,1,0,14,15,1,0,61,62,2,0,55,55,57,57,1,0,23,24,1,0,55,58,1,0,45,46,
-	1,0,1,2,1,0,76,77,1,0,90,91,2,0,81,81,83,83,805,0,85,1,0,0,0,2,99,1,0,0,
-	0,4,117,1,0,0,0,6,149,1,0,0,0,8,163,1,0,0,0,10,166,1,0,0,0,12,170,1,0,0,
-	0,14,175,1,0,0,0,16,180,1,0,0,0,18,187,1,0,0,0,20,192,1,0,0,0,22,197,1,
-	0,0,0,24,203,1,0,0,0,26,218,1,0,0,0,28,225,1,0,0,0,30,239,1,0,0,0,32,262,
-	1,0,0,0,34,287,1,0,0,0,36,315,1,0,0,0,38,369,1,0,0,0,40,373,1,0,0,0,42,
-	375,1,0,0,0,44,382,1,0,0,0,46,388,1,0,0,0,48,395,1,0,0,0,50,399,1,0,0,0,
-	52,405,1,0,0,0,54,413,1,0,0,0,56,436,1,0,0,0,58,576,1,0,0,0,60,643,1,0,
-	0,0,62,647,1,0,0,0,64,661,1,0,0,0,66,685,1,0,0,0,68,86,3,14,7,0,69,86,3,
-	16,8,0,70,86,3,18,9,0,71,86,3,20,10,0,72,86,3,22,11,0,73,86,3,60,30,0,74,
-	86,3,10,5,0,75,86,3,8,4,0,76,86,3,42,21,0,77,86,3,44,22,0,78,86,3,46,23,
-	0,79,86,3,58,29,0,80,86,3,40,20,0,81,86,3,24,12,0,82,86,3,6,3,0,83,86,3,
-	2,1,0,84,86,3,4,2,0,85,68,1,0,0,0,85,69,1,0,0,0,85,70,1,0,0,0,85,71,1,0,
-	0,0,85,72,1,0,0,0,85,73,1,0,0,0,85,74,1,0,0,0,85,75,1,0,0,0,85,76,1,0,0,
-	0,85,77,1,0,0,0,85,78,1,0,0,0,85,79,1,0,0,0,85,80,1,0,0,0,85,81,1,0,0,0,
-	85,82,1,0,0,0,85,83,1,0,0,0,85,84,1,0,0,0,85,86,1,0,0,0,86,87,1,0,0,0,87,
-	88,5,0,0,1,88,1,1,0,0,0,89,90,5,6,0,0,90,91,3,58,29,0,91,92,5,59,0,0,92,
-	93,3,58,29,0,93,94,5,7,0,0,94,100,1,0,0,0,95,96,3,58,29,0,96,97,5,59,0,
-	0,97,98,3,58,29,0,98,100,1,0,0,0,99,89,1,0,0,0,99,95,1,0,0,0,100,102,1,
-	0,0,0,101,103,5,28,0,0,102,101,1,0,0,0,102,103,1,0,0,0,103,104,1,0,0,0,
-	104,115,5,54,0,0,105,106,5,6,0,0,106,107,3,60,30,0,107,108,5,59,0,0,108,
-	109,3,60,30,0,109,110,5,7,0,0,110,116,1,0,0,0,111,112,3,60,30,0,112,113,
-	5,59,0,0,113,114,3,60,30,0,114,116,1,0,0,0,115,105,1,0,0,0,115,111,1,0,
-	0,0,115,116,1,0,0,0,116,3,1,0,0,0,117,118,5,6,0,0,118,119,3,58,29,0,119,
-	120,5,59,0,0,120,121,3,58,29,0,121,122,5,7,0,0,122,123,1,0,0,0,123,124,
-	5,70,0,0,124,125,5,6,0,0,125,126,3,38,19,0,126,131,5,7,0,0,127,128,5,70,
-	0,0,128,129,3,10,5,0,129,130,5,70,0,0,130,132,1,0,0,0,131,127,1,0,0,0,131,
-	132,1,0,0,0,132,133,1,0,0,0,133,144,5,54,0,0,134,135,5,6,0,0,135,136,3,
-	60,30,0,136,137,5,59,0,0,137,138,3,60,30,0,138,139,5,7,0,0,139,145,1,0,
-	0,0,140,141,3,60,30,0,141,142,5,59,0,0,142,143,3,60,30,0,143,145,1,0,0,
-	0,144,134,1,0,0,0,144,140,1,0,0,0,144,145,1,0,0,0,145,5,1,0,0,0,146,148,
-	9,0,0,0,147,146,1,0,0,0,148,151,1,0,0,0,149,150,1,0,0,0,149,147,1,0,0,0,
-	150,159,1,0,0,0,151,149,1,0,0,0,152,156,3,62,31,0,153,155,9,0,0,0,154,153,
-	1,0,0,0,155,158,1,0,0,0,156,157,1,0,0,0,156,154,1,0,0,0,157,160,1,0,0,0,
-	158,156,1,0,0,0,159,152,1,0,0,0,160,161,1,0,0,0,161,159,1,0,0,0,161,162,
-	1,0,0,0,162,7,1,0,0,0,163,164,5,70,0,0,164,9,1,0,0,0,165,167,5,52,0,0,166,
-	165,1,0,0,0,166,167,1,0,0,0,167,168,1,0,0,0,168,169,5,63,0,0,169,11,1,0,
-	0,0,170,171,3,10,5,0,171,172,3,60,30,0,172,13,1,0,0,0,173,176,3,8,4,0,174,
-	176,5,11,0,0,175,173,1,0,0,0,175,174,1,0,0,0,176,177,1,0,0,0,177,178,5,
-	54,0,0,178,179,3,58,29,0,179,15,1,0,0,0,180,183,3,14,7,0,181,182,5,59,0,
-	0,182,184,3,14,7,0,183,181,1,0,0,0,184,185,1,0,0,0,185,183,1,0,0,0,185,
-	186,1,0,0,0,186,17,1,0,0,0,187,188,3,14,7,0,188,190,5,54,0,0,189,191,3,
-	60,30,0,190,189,1,0,0,0,190,191,1,0,0,0,191,19,1,0,0,0,192,193,3,58,29,
-	0,193,195,5,54,0,0,194,196,3,60,30,0,195,194,1,0,0,0,195,196,1,0,0,0,196,
-	21,1,0,0,0,197,198,3,58,29,0,198,199,5,54,0,0,199,200,3,58,29,0,200,23,
-	1,0,0,0,201,204,3,8,4,0,202,204,5,11,0,0,203,201,1,0,0,0,203,202,1,0,0,
-	0,204,205,1,0,0,0,205,206,5,54,0,0,206,207,3,8,4,0,207,208,5,6,0,0,208,
-	213,3,26,13,0,209,210,5,59,0,0,210,212,3,26,13,0,211,209,1,0,0,0,212,215,
-	1,0,0,0,213,211,1,0,0,0,213,214,1,0,0,0,214,216,1,0,0,0,215,213,1,0,0,0,
-	216,217,5,7,0,0,217,25,1,0,0,0,218,219,5,6,0,0,219,220,3,58,29,0,220,221,
-	5,59,0,0,221,222,3,40,20,0,222,223,5,7,0,0,223,27,1,0,0,0,224,226,5,27,
-	0,0,225,224,1,0,0,0,225,226,1,0,0,0,226,227,1,0,0,0,227,228,7,0,0,0,228,
-	229,5,6,0,0,229,230,3,58,29,0,230,231,5,7,0,0,231,29,1,0,0,0,232,240,5,
-	12,0,0,233,234,5,13,0,0,234,235,5,4,0,0,235,236,5,5,0,0,236,237,5,53,0,
-	0,237,238,5,4,0,0,238,240,5,5,0,0,239,232,1,0,0,0,239,233,1,0,0,0,240,241,
-	1,0,0,0,241,242,5,6,0,0,242,243,3,58,29,0,243,250,5,7,0,0,244,245,5,16,
-	0,0,245,246,5,4,0,0,246,247,3,8,4,0,247,248,5,5,0,0,248,251,1,0,0,0,249,
-	251,3,8,4,0,250,244,1,0,0,0,250,249,1,0,0,0,251,252,1,0,0,0,252,253,5,6,
-	0,0,253,254,3,8,4,0,254,255,5,7,0,0,255,31,1,0,0,0,256,257,5,13,0,0,257,
-	258,5,4,0,0,258,259,3,58,29,0,259,260,5,5,0,0,260,263,1,0,0,0,261,263,7,
-	1,0,0,262,256,1,0,0,0,262,261,1,0,0,0,263,270,1,0,0,0,264,265,5,53,0,0,
-	265,266,5,4,0,0,266,267,3,58,29,0,267,268,5,5,0,0,268,271,1,0,0,0,269,271,
-	7,2,0,0,270,264,1,0,0,0,270,269,1,0,0,0,271,272,1,0,0,0,272,273,5,6,0,0,
-	273,274,3,58,29,0,274,281,5,7,0,0,275,276,5,16,0,0,276,277,5,4,0,0,277,
-	278,3,8,4,0,278,279,5,5,0,0,279,282,1,0,0,0,280,282,3,8,4,0,281,275,1,0,
-	0,0,281,280,1,0,0,0,282,283,1,0,0,0,283,284,5,6,0,0,284,285,3,8,4,0,285,
-	286,5,7,0,0,286,33,1,0,0,0,287,288,5,17,0,0,288,295,5,4,0,0,289,290,5,16,
-	0,0,290,291,5,4,0,0,291,292,3,8,4,0,292,293,5,5,0,0,293,296,1,0,0,0,294,
-	296,3,8,4,0,295,289,1,0,0,0,295,294,1,0,0,0,296,297,1,0,0,0,297,298,5,5,
-	0,0,298,305,5,4,0,0,299,300,5,16,0,0,300,301,5,4,0,0,301,302,3,8,4,0,302,
-	303,5,5,0,0,303,306,1,0,0,0,304,306,3,8,4,0,305,299,1,0,0,0,305,304,1,0,
-	0,0,306,307,1,0,0,0,307,308,5,6,0,0,308,309,3,8,4,0,309,310,5,7,0,0,310,
-	311,5,5,0,0,311,312,5,6,0,0,312,313,3,58,29,0,313,314,5,7,0,0,314,35,1,
-	0,0,0,315,316,5,17,0,0,316,323,5,4,0,0,317,318,5,16,0,0,318,319,5,4,0,0,
-	319,320,3,8,4,0,320,321,5,5,0,0,321,324,1,0,0,0,322,324,3,8,4,0,323,317,
-	1,0,0,0,323,322,1,0,0,0,324,331,1,0,0,0,325,326,5,53,0,0,326,327,5,4,0,
-	0,327,328,3,10,5,0,328,329,5,5,0,0,329,332,1,0,0,0,330,332,5,61,0,0,331,
-	325,1,0,0,0,331,330,1,0,0,0,332,333,1,0,0,0,333,334,5,5,0,0,334,341,5,4,
-	0,0,335,336,5,16,0,0,336,337,5,4,0,0,337,338,3,8,4,0,338,339,5,5,0,0,339,
-	342,1,0,0,0,340,342,3,8,4,0,341,335,1,0,0,0,341,340,1,0,0,0,342,343,1,0,
-	0,0,343,344,5,6,0,0,344,345,3,8,4,0,345,352,5,7,0,0,346,347,5,53,0,0,347,
-	348,5,4,0,0,348,349,3,10,5,0,349,350,5,5,0,0,350,353,1,0,0,0,351,353,5,
-	61,0,0,352,346,1,0,0,0,352,351,1,0,0,0,353,354,1,0,0,0,354,355,5,5,0,0,
-	355,356,5,6,0,0,356,357,3,58,29,0,357,358,5,7,0,0,358,37,1,0,0,0,359,360,
-	3,8,4,0,360,361,5,54,0,0,361,362,3,58,29,0,362,370,1,0,0,0,363,364,3,58,
-	29,0,364,365,7,3,0,0,365,366,3,8,4,0,366,367,7,3,0,0,367,368,3,58,29,0,
-	368,370,1,0,0,0,369,359,1,0,0,0,369,363,1,0,0,0,370,39,1,0,0,0,371,374,
-	3,48,24,0,372,374,3,50,25,0,373,371,1,0,0,0,373,372,1,0,0,0,374,41,1,0,
-	0,0,375,378,3,8,4,0,376,377,5,59,0,0,377,379,3,8,4,0,378,376,1,0,0,0,379,
-	380,1,0,0,0,380,378,1,0,0,0,380,381,1,0,0,0,381,43,1,0,0,0,382,383,3,8,
-	4,0,383,386,7,4,0,0,384,387,3,10,5,0,385,387,3,12,6,0,386,384,1,0,0,0,386,
-	385,1,0,0,0,387,45,1,0,0,0,388,391,3,44,22,0,389,390,5,59,0,0,390,392,3,
-	44,22,0,391,389,1,0,0,0,392,393,1,0,0,0,393,391,1,0,0,0,393,394,1,0,0,0,
-	394,47,1,0,0,0,395,396,3,58,29,0,396,397,7,5,0,0,397,398,3,58,29,0,398,
-	49,1,0,0,0,399,400,3,58,29,0,400,401,7,5,0,0,401,402,3,58,29,0,402,403,
-	7,5,0,0,403,404,3,58,29,0,404,51,1,0,0,0,405,410,3,58,29,0,406,407,5,66,
-	0,0,407,409,3,58,29,0,408,406,1,0,0,0,409,412,1,0,0,0,410,408,1,0,0,0,410,
-	411,1,0,0,0,411,53,1,0,0,0,412,410,1,0,0,0,413,414,3,8,4,0,414,415,5,6,
-	0,0,415,420,3,38,19,0,416,417,5,59,0,0,417,419,3,38,19,0,418,416,1,0,0,
-	0,419,422,1,0,0,0,420,418,1,0,0,0,420,421,1,0,0,0,421,423,1,0,0,0,422,420,
-	1,0,0,0,423,428,5,7,0,0,424,425,5,70,0,0,425,426,3,10,5,0,426,427,5,70,
-	0,0,427,429,1,0,0,0,428,424,1,0,0,0,428,429,1,0,0,0,429,55,1,0,0,0,430,
-	431,5,16,0,0,431,432,5,4,0,0,432,433,3,8,4,0,433,434,5,5,0,0,434,437,1,
-	0,0,0,435,437,3,8,4,0,436,430,1,0,0,0,436,435,1,0,0,0,437,438,1,0,0,0,438,
-	439,5,6,0,0,439,444,3,58,29,0,440,441,5,59,0,0,441,443,3,58,29,0,442,440,
-	1,0,0,0,443,446,1,0,0,0,444,442,1,0,0,0,444,445,1,0,0,0,445,447,1,0,0,0,
-	446,444,1,0,0,0,447,448,5,7,0,0,448,57,1,0,0,0,449,450,6,29,-1,0,450,451,
-	3,8,4,0,451,452,5,69,0,0,452,577,1,0,0,0,453,454,3,8,4,0,454,455,7,2,0,
-	0,455,456,5,68,0,0,456,577,1,0,0,0,457,458,3,8,4,0,458,459,5,53,0,0,459,
-	460,5,4,0,0,460,461,3,58,29,0,461,462,5,5,0,0,462,463,5,68,0,0,463,577,
-	1,0,0,0,464,577,5,22,0,0,465,466,5,21,0,0,466,467,5,4,0,0,467,468,3,58,
-	29,0,468,469,5,5,0,0,469,577,1,0,0,0,470,471,5,64,0,0,471,476,3,52,26,0,
-	472,473,5,67,0,0,473,475,3,52,26,0,474,472,1,0,0,0,475,478,1,0,0,0,476,
-	474,1,0,0,0,476,477,1,0,0,0,477,479,1,0,0,0,478,476,1,0,0,0,479,480,5,65,
-	0,0,480,577,1,0,0,0,481,577,3,28,14,0,482,577,3,30,15,0,483,577,3,32,16,
-	0,484,577,3,34,17,0,485,577,3,36,18,0,486,488,5,27,0,0,487,486,1,0,0,0,
-	487,488,1,0,0,0,488,489,1,0,0,0,489,490,5,42,0,0,490,491,5,6,0,0,491,492,
-	3,58,29,0,492,493,5,7,0,0,493,577,1,0,0,0,494,496,5,27,0,0,495,494,1,0,
-	0,0,495,496,1,0,0,0,496,497,1,0,0,0,497,498,5,43,0,0,498,499,5,6,0,0,499,
-	500,3,58,29,0,500,501,5,7,0,0,501,577,1,0,0,0,502,503,5,44,0,0,503,504,
-	5,4,0,0,504,505,3,58,29,0,505,506,5,5,0,0,506,507,5,6,0,0,507,508,3,58,
-	29,0,508,509,5,7,0,0,509,577,1,0,0,0,510,511,7,6,0,0,511,512,5,6,0,0,512,
-	513,3,58,29,0,513,514,5,7,0,0,514,577,1,0,0,0,515,516,5,9,0,0,516,517,3,
-	58,29,0,517,518,5,9,0,0,518,577,1,0,0,0,519,520,5,8,0,0,520,521,3,58,29,
-	0,521,522,5,8,0,0,522,577,1,0,0,0,523,577,3,12,6,0,524,577,3,10,5,0,525,
-	526,5,52,0,0,526,577,3,58,29,30,527,528,5,17,0,0,528,529,5,4,0,0,529,530,
-	3,58,29,0,530,531,5,5,0,0,531,532,5,4,0,0,532,533,3,58,29,0,533,534,5,5,
-	0,0,534,577,1,0,0,0,535,577,5,18,0,0,536,577,3,8,4,0,537,577,3,54,27,0,
-	538,577,3,56,28,0,539,577,5,11,0,0,540,541,5,6,0,0,541,542,3,58,29,0,542,
-	543,5,7,0,0,543,577,1,0,0,0,544,545,3,10,5,0,545,546,3,58,29,12,546,577,
-	1,0,0,0,547,548,3,12,6,0,548,549,3,58,29,11,549,577,1,0,0,0,550,551,5,11,
-	0,0,551,577,3,58,29,10,552,555,5,25,0,0,553,554,5,4,0,0,554,556,5,5,0,0,
-	555,553,1,0,0,0,555,556,1,0,0,0,556,577,1,0,0,0,557,558,5,16,0,0,558,559,
-	5,4,0,0,559,560,3,58,29,0,560,561,5,5,0,0,561,563,1,0,0,0,562,557,1,0,0,
-	0,562,563,1,0,0,0,563,566,1,0,0,0,564,567,5,60,0,0,565,567,3,10,5,0,566,
-	564,1,0,0,0,566,565,1,0,0,0,566,567,1,0,0,0,567,568,1,0,0,0,568,569,5,16,
-	0,0,569,570,5,4,0,0,570,571,3,58,29,0,571,574,5,5,0,0,572,575,5,60,0,0,
-	573,575,3,10,5,0,574,572,1,0,0,0,574,573,1,0,0,0,574,575,1,0,0,0,575,577,
-	1,0,0,0,576,449,1,0,0,0,576,453,1,0,0,0,576,457,1,0,0,0,576,464,1,0,0,0,
-	576,465,1,0,0,0,576,470,1,0,0,0,576,481,1,0,0,0,576,482,1,0,0,0,576,483,
-	1,0,0,0,576,484,1,0,0,0,576,485,1,0,0,0,576,487,1,0,0,0,576,495,1,0,0,0,
-	576,502,1,0,0,0,576,510,1,0,0,0,576,515,1,0,0,0,576,519,1,0,0,0,576,523,
-	1,0,0,0,576,524,1,0,0,0,576,525,1,0,0,0,576,527,1,0,0,0,576,535,1,0,0,0,
-	576,536,1,0,0,0,576,537,1,0,0,0,576,538,1,0,0,0,576,539,1,0,0,0,576,540,
-	1,0,0,0,576,544,1,0,0,0,576,547,1,0,0,0,576,550,1,0,0,0,576,552,1,0,0,0,
-	576,562,1,0,0,0,577,640,1,0,0,0,578,579,10,29,0,0,579,580,5,20,0,0,580,
-	639,3,58,29,30,581,582,10,28,0,0,582,583,5,19,0,0,583,639,3,58,29,29,584,
-	585,10,25,0,0,585,586,5,52,0,0,586,639,3,58,29,26,587,588,10,24,0,0,588,
-	589,5,51,0,0,589,639,3,58,29,25,590,591,10,50,0,0,591,639,7,2,0,0,592,593,
-	10,49,0,0,593,594,5,53,0,0,594,595,5,4,0,0,595,596,3,58,29,0,596,597,5,
-	5,0,0,597,639,1,0,0,0,598,599,10,48,0,0,599,600,5,10,0,0,600,601,5,4,0,
-	0,601,602,3,58,29,0,602,603,5,59,0,0,603,604,3,58,29,0,604,605,5,5,0,0,
-	605,639,1,0,0,0,606,607,10,47,0,0,607,639,5,26,0,0,608,609,10,18,0,0,609,
-	610,5,10,0,0,610,611,5,4,0,0,611,639,5,5,0,0,612,613,10,17,0,0,613,614,
-	5,53,0,0,614,615,5,4,0,0,615,639,5,5,0,0,616,617,10,16,0,0,617,639,3,8,
-	4,0,618,619,10,15,0,0,619,639,3,10,5,0,620,621,10,14,0,0,621,639,3,12,6,
-	0,622,623,10,13,0,0,623,639,5,11,0,0,624,625,10,9,0,0,625,639,3,54,27,0,
-	626,627,10,8,0,0,627,639,3,56,28,0,628,629,10,7,0,0,629,639,3,28,14,0,630,
-	631,10,6,0,0,631,639,3,30,15,0,632,633,10,5,0,0,633,639,3,32,16,0,634,635,
-	10,4,0,0,635,639,3,34,17,0,636,637,10,3,0,0,637,639,3,36,18,0,638,578,1,
-	0,0,0,638,581,1,0,0,0,638,584,1,0,0,0,638,587,1,0,0,0,638,590,1,0,0,0,638,
-	592,1,0,0,0,638,598,1,0,0,0,638,606,1,0,0,0,638,608,1,0,0,0,638,612,1,0,
-	0,0,638,616,1,0,0,0,638,618,1,0,0,0,638,620,1,0,0,0,638,622,1,0,0,0,638,
-	624,1,0,0,0,638,626,1,0,0,0,638,628,1,0,0,0,638,630,1,0,0,0,638,632,1,0,
-	0,0,638,634,1,0,0,0,638,636,1,0,0,0,639,642,1,0,0,0,640,638,1,0,0,0,640,
-	641,1,0,0,0,641,59,1,0,0,0,642,640,1,0,0,0,643,644,7,7,0,0,644,645,3,66,
-	33,0,645,646,7,8,0,0,646,61,1,0,0,0,647,648,7,7,0,0,648,649,7,9,0,0,649,
-	650,7,10,0,0,650,651,7,9,0,0,651,652,7,8,0,0,652,63,1,0,0,0,653,654,5,78,
-	0,0,654,655,5,88,0,0,655,656,7,9,0,0,656,657,5,89,0,0,657,658,5,88,0,0,
-	658,659,5,91,0,0,659,662,5,89,0,0,660,662,5,79,0,0,661,653,1,0,0,0,661,
-	660,1,0,0,0,662,65,1,0,0,0,663,664,6,33,-1,0,664,665,5,82,0,0,665,666,5,
-	88,0,0,666,667,3,58,29,0,667,668,5,89,0,0,668,686,1,0,0,0,669,670,5,78,
-	0,0,670,673,5,88,0,0,671,674,3,66,33,0,672,674,5,90,0,0,673,671,1,0,0,0,
-	673,672,1,0,0,0,674,675,1,0,0,0,675,676,5,89,0,0,676,677,5,88,0,0,677,678,
-	3,66,33,0,678,679,5,89,0,0,679,686,1,0,0,0,680,686,5,85,0,0,681,682,5,86,
-	0,0,682,683,3,66,33,0,683,684,5,87,0,0,684,686,1,0,0,0,685,663,1,0,0,0,
-	685,669,1,0,0,0,685,680,1,0,0,0,685,681,1,0,0,0,686,709,1,0,0,0,687,688,
-	10,4,0,0,688,689,5,80,0,0,689,708,3,66,33,5,690,691,10,9,0,0,691,692,5,
-	84,0,0,692,708,5,91,0,0,693,694,10,8,0,0,694,695,5,84,0,0,695,696,5,88,
-	0,0,696,697,5,91,0,0,697,708,5,89,0,0,698,699,10,7,0,0,699,700,5,84,0,0,
-	700,708,3,64,32,0,701,702,10,6,0,0,702,703,5,84,0,0,703,704,5,88,0,0,704,
-	705,3,64,32,0,705,706,5,89,0,0,706,708,1,0,0,0,707,687,1,0,0,0,707,690,
-	1,0,0,0,707,693,1,0,0,0,707,698,1,0,0,0,707,701,1,0,0,0,708,711,1,0,0,0,
-	709,707,1,0,0,0,709,710,1,0,0,0,710,67,1,0,0,0,711,709,1,0,0,0,53,85,99,
-	102,115,131,144,149,156,161,166,175,185,190,195,203,213,225,239,250,262,
-	270,281,295,305,323,331,341,352,369,373,380,386,393,410,420,428,436,444,
-	476,487,495,555,562,566,574,576,638,640,661,673,685,707,709];
+	29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,1,29,5,29,641,8,29,10,29,
+	12,29,644,9,29,1,30,1,30,1,30,1,30,1,31,1,31,1,31,1,31,1,31,1,31,1,32,1,
+	32,1,32,1,32,1,32,1,32,1,32,1,32,3,32,664,8,32,1,33,1,33,1,33,1,33,1,33,
+	1,33,1,33,1,33,1,33,1,33,3,33,676,8,33,1,33,1,33,1,33,1,33,1,33,1,33,1,
+	33,1,33,1,33,1,33,3,33,688,8,33,1,33,1,33,1,33,1,33,1,33,1,33,1,33,1,33,
+	1,33,1,33,1,33,1,33,1,33,1,33,1,33,1,33,1,33,1,33,1,33,1,33,5,33,710,8,
+	33,10,33,12,33,713,9,33,1,33,2,149,156,2,58,66,34,0,2,4,6,8,10,12,14,16,
+	18,20,22,24,26,28,30,32,34,36,38,40,42,44,46,48,50,52,54,56,58,60,62,64,
+	66,0,11,1,0,29,41,1,0,14,15,1,0,61,62,2,0,55,55,57,57,1,0,23,24,1,0,55,
+	58,1,0,45,46,1,0,1,2,1,0,76,77,1,0,90,91,2,0,81,81,83,83,809,0,85,1,0,0,
+	0,2,99,1,0,0,0,4,117,1,0,0,0,6,149,1,0,0,0,8,163,1,0,0,0,10,166,1,0,0,0,
+	12,170,1,0,0,0,14,175,1,0,0,0,16,180,1,0,0,0,18,187,1,0,0,0,20,192,1,0,
+	0,0,22,197,1,0,0,0,24,203,1,0,0,0,26,218,1,0,0,0,28,225,1,0,0,0,30,239,
+	1,0,0,0,32,262,1,0,0,0,34,287,1,0,0,0,36,315,1,0,0,0,38,369,1,0,0,0,40,
+	373,1,0,0,0,42,375,1,0,0,0,44,382,1,0,0,0,46,388,1,0,0,0,48,395,1,0,0,0,
+	50,399,1,0,0,0,52,405,1,0,0,0,54,413,1,0,0,0,56,436,1,0,0,0,58,578,1,0,
+	0,0,60,645,1,0,0,0,62,649,1,0,0,0,64,663,1,0,0,0,66,687,1,0,0,0,68,86,3,
+	14,7,0,69,86,3,16,8,0,70,86,3,18,9,0,71,86,3,20,10,0,72,86,3,22,11,0,73,
+	86,3,60,30,0,74,86,3,10,5,0,75,86,3,8,4,0,76,86,3,42,21,0,77,86,3,44,22,
+	0,78,86,3,46,23,0,79,86,3,58,29,0,80,86,3,40,20,0,81,86,3,24,12,0,82,86,
+	3,6,3,0,83,86,3,2,1,0,84,86,3,4,2,0,85,68,1,0,0,0,85,69,1,0,0,0,85,70,1,
+	0,0,0,85,71,1,0,0,0,85,72,1,0,0,0,85,73,1,0,0,0,85,74,1,0,0,0,85,75,1,0,
+	0,0,85,76,1,0,0,0,85,77,1,0,0,0,85,78,1,0,0,0,85,79,1,0,0,0,85,80,1,0,0,
+	0,85,81,1,0,0,0,85,82,1,0,0,0,85,83,1,0,0,0,85,84,1,0,0,0,85,86,1,0,0,0,
+	86,87,1,0,0,0,87,88,5,0,0,1,88,1,1,0,0,0,89,90,5,6,0,0,90,91,3,58,29,0,
+	91,92,5,59,0,0,92,93,3,58,29,0,93,94,5,7,0,0,94,100,1,0,0,0,95,96,3,58,
+	29,0,96,97,5,59,0,0,97,98,3,58,29,0,98,100,1,0,0,0,99,89,1,0,0,0,99,95,
+	1,0,0,0,100,102,1,0,0,0,101,103,5,28,0,0,102,101,1,0,0,0,102,103,1,0,0,
+	0,103,104,1,0,0,0,104,115,5,54,0,0,105,106,5,6,0,0,106,107,3,60,30,0,107,
+	108,5,59,0,0,108,109,3,60,30,0,109,110,5,7,0,0,110,116,1,0,0,0,111,112,
+	3,60,30,0,112,113,5,59,0,0,113,114,3,60,30,0,114,116,1,0,0,0,115,105,1,
+	0,0,0,115,111,1,0,0,0,115,116,1,0,0,0,116,3,1,0,0,0,117,118,5,6,0,0,118,
+	119,3,58,29,0,119,120,5,59,0,0,120,121,3,58,29,0,121,122,5,7,0,0,122,123,
+	1,0,0,0,123,124,5,70,0,0,124,125,5,6,0,0,125,126,3,38,19,0,126,131,5,7,
+	0,0,127,128,5,70,0,0,128,129,3,10,5,0,129,130,5,70,0,0,130,132,1,0,0,0,
+	131,127,1,0,0,0,131,132,1,0,0,0,132,133,1,0,0,0,133,144,5,54,0,0,134,135,
+	5,6,0,0,135,136,3,60,30,0,136,137,5,59,0,0,137,138,3,60,30,0,138,139,5,
+	7,0,0,139,145,1,0,0,0,140,141,3,60,30,0,141,142,5,59,0,0,142,143,3,60,30,
+	0,143,145,1,0,0,0,144,134,1,0,0,0,144,140,1,0,0,0,144,145,1,0,0,0,145,5,
+	1,0,0,0,146,148,9,0,0,0,147,146,1,0,0,0,148,151,1,0,0,0,149,150,1,0,0,0,
+	149,147,1,0,0,0,150,159,1,0,0,0,151,149,1,0,0,0,152,156,3,62,31,0,153,155,
+	9,0,0,0,154,153,1,0,0,0,155,158,1,0,0,0,156,157,1,0,0,0,156,154,1,0,0,0,
+	157,160,1,0,0,0,158,156,1,0,0,0,159,152,1,0,0,0,160,161,1,0,0,0,161,159,
+	1,0,0,0,161,162,1,0,0,0,162,7,1,0,0,0,163,164,5,70,0,0,164,9,1,0,0,0,165,
+	167,5,52,0,0,166,165,1,0,0,0,166,167,1,0,0,0,167,168,1,0,0,0,168,169,5,
+	63,0,0,169,11,1,0,0,0,170,171,3,10,5,0,171,172,3,60,30,0,172,13,1,0,0,0,
+	173,176,3,8,4,0,174,176,5,11,0,0,175,173,1,0,0,0,175,174,1,0,0,0,176,177,
+	1,0,0,0,177,178,5,54,0,0,178,179,3,58,29,0,179,15,1,0,0,0,180,183,3,14,
+	7,0,181,182,5,59,0,0,182,184,3,14,7,0,183,181,1,0,0,0,184,185,1,0,0,0,185,
+	183,1,0,0,0,185,186,1,0,0,0,186,17,1,0,0,0,187,188,3,14,7,0,188,190,5,54,
+	0,0,189,191,3,60,30,0,190,189,1,0,0,0,190,191,1,0,0,0,191,19,1,0,0,0,192,
+	193,3,58,29,0,193,195,5,54,0,0,194,196,3,60,30,0,195,194,1,0,0,0,195,196,
+	1,0,0,0,196,21,1,0,0,0,197,198,3,58,29,0,198,199,5,54,0,0,199,200,3,58,
+	29,0,200,23,1,0,0,0,201,204,3,8,4,0,202,204,5,11,0,0,203,201,1,0,0,0,203,
+	202,1,0,0,0,204,205,1,0,0,0,205,206,5,54,0,0,206,207,3,8,4,0,207,208,5,
+	6,0,0,208,213,3,26,13,0,209,210,5,59,0,0,210,212,3,26,13,0,211,209,1,0,
+	0,0,212,215,1,0,0,0,213,211,1,0,0,0,213,214,1,0,0,0,214,216,1,0,0,0,215,
+	213,1,0,0,0,216,217,5,7,0,0,217,25,1,0,0,0,218,219,5,6,0,0,219,220,3,58,
+	29,0,220,221,5,59,0,0,221,222,3,40,20,0,222,223,5,7,0,0,223,27,1,0,0,0,
+	224,226,5,27,0,0,225,224,1,0,0,0,225,226,1,0,0,0,226,227,1,0,0,0,227,228,
+	7,0,0,0,228,229,5,6,0,0,229,230,3,58,29,0,230,231,5,7,0,0,231,29,1,0,0,
+	0,232,240,5,12,0,0,233,234,5,13,0,0,234,235,5,4,0,0,235,236,5,5,0,0,236,
+	237,5,53,0,0,237,238,5,4,0,0,238,240,5,5,0,0,239,232,1,0,0,0,239,233,1,
+	0,0,0,240,241,1,0,0,0,241,242,5,6,0,0,242,243,3,58,29,0,243,250,5,7,0,0,
+	244,245,5,16,0,0,245,246,5,4,0,0,246,247,3,8,4,0,247,248,5,5,0,0,248,251,
+	1,0,0,0,249,251,3,8,4,0,250,244,1,0,0,0,250,249,1,0,0,0,251,252,1,0,0,0,
+	252,253,5,6,0,0,253,254,3,8,4,0,254,255,5,7,0,0,255,31,1,0,0,0,256,257,
+	5,13,0,0,257,258,5,4,0,0,258,259,3,58,29,0,259,260,5,5,0,0,260,263,1,0,
+	0,0,261,263,7,1,0,0,262,256,1,0,0,0,262,261,1,0,0,0,263,270,1,0,0,0,264,
+	265,5,53,0,0,265,266,5,4,0,0,266,267,3,58,29,0,267,268,5,5,0,0,268,271,
+	1,0,0,0,269,271,7,2,0,0,270,264,1,0,0,0,270,269,1,0,0,0,271,272,1,0,0,0,
+	272,273,5,6,0,0,273,274,3,58,29,0,274,281,5,7,0,0,275,276,5,16,0,0,276,
+	277,5,4,0,0,277,278,3,8,4,0,278,279,5,5,0,0,279,282,1,0,0,0,280,282,3,8,
+	4,0,281,275,1,0,0,0,281,280,1,0,0,0,282,283,1,0,0,0,283,284,5,6,0,0,284,
+	285,3,8,4,0,285,286,5,7,0,0,286,33,1,0,0,0,287,288,5,17,0,0,288,295,5,4,
+	0,0,289,290,5,16,0,0,290,291,5,4,0,0,291,292,3,8,4,0,292,293,5,5,0,0,293,
+	296,1,0,0,0,294,296,3,8,4,0,295,289,1,0,0,0,295,294,1,0,0,0,296,297,1,0,
+	0,0,297,298,5,5,0,0,298,305,5,4,0,0,299,300,5,16,0,0,300,301,5,4,0,0,301,
+	302,3,8,4,0,302,303,5,5,0,0,303,306,1,0,0,0,304,306,3,8,4,0,305,299,1,0,
+	0,0,305,304,1,0,0,0,306,307,1,0,0,0,307,308,5,6,0,0,308,309,3,8,4,0,309,
+	310,5,7,0,0,310,311,5,5,0,0,311,312,5,6,0,0,312,313,3,58,29,0,313,314,5,
+	7,0,0,314,35,1,0,0,0,315,316,5,17,0,0,316,323,5,4,0,0,317,318,5,16,0,0,
+	318,319,5,4,0,0,319,320,3,8,4,0,320,321,5,5,0,0,321,324,1,0,0,0,322,324,
+	3,8,4,0,323,317,1,0,0,0,323,322,1,0,0,0,324,331,1,0,0,0,325,326,5,53,0,
+	0,326,327,5,4,0,0,327,328,3,10,5,0,328,329,5,5,0,0,329,332,1,0,0,0,330,
+	332,5,61,0,0,331,325,1,0,0,0,331,330,1,0,0,0,332,333,1,0,0,0,333,334,5,
+	5,0,0,334,341,5,4,0,0,335,336,5,16,0,0,336,337,5,4,0,0,337,338,3,8,4,0,
+	338,339,5,5,0,0,339,342,1,0,0,0,340,342,3,8,4,0,341,335,1,0,0,0,341,340,
+	1,0,0,0,342,343,1,0,0,0,343,344,5,6,0,0,344,345,3,8,4,0,345,352,5,7,0,0,
+	346,347,5,53,0,0,347,348,5,4,0,0,348,349,3,10,5,0,349,350,5,5,0,0,350,353,
+	1,0,0,0,351,353,5,61,0,0,352,346,1,0,0,0,352,351,1,0,0,0,353,354,1,0,0,
+	0,354,355,5,5,0,0,355,356,5,6,0,0,356,357,3,58,29,0,357,358,5,7,0,0,358,
+	37,1,0,0,0,359,360,3,8,4,0,360,361,5,54,0,0,361,362,3,58,29,0,362,370,1,
+	0,0,0,363,364,3,58,29,0,364,365,7,3,0,0,365,366,3,8,4,0,366,367,7,3,0,0,
+	367,368,3,58,29,0,368,370,1,0,0,0,369,359,1,0,0,0,369,363,1,0,0,0,370,39,
+	1,0,0,0,371,374,3,48,24,0,372,374,3,50,25,0,373,371,1,0,0,0,373,372,1,0,
+	0,0,374,41,1,0,0,0,375,378,3,8,4,0,376,377,5,59,0,0,377,379,3,8,4,0,378,
+	376,1,0,0,0,379,380,1,0,0,0,380,378,1,0,0,0,380,381,1,0,0,0,381,43,1,0,
+	0,0,382,383,3,8,4,0,383,386,7,4,0,0,384,387,3,10,5,0,385,387,3,12,6,0,386,
+	384,1,0,0,0,386,385,1,0,0,0,387,45,1,0,0,0,388,391,3,44,22,0,389,390,5,
+	59,0,0,390,392,3,44,22,0,391,389,1,0,0,0,392,393,1,0,0,0,393,391,1,0,0,
+	0,393,394,1,0,0,0,394,47,1,0,0,0,395,396,3,58,29,0,396,397,7,5,0,0,397,
+	398,3,58,29,0,398,49,1,0,0,0,399,400,3,58,29,0,400,401,7,5,0,0,401,402,
+	3,58,29,0,402,403,7,5,0,0,403,404,3,58,29,0,404,51,1,0,0,0,405,410,3,58,
+	29,0,406,407,5,66,0,0,407,409,3,58,29,0,408,406,1,0,0,0,409,412,1,0,0,0,
+	410,408,1,0,0,0,410,411,1,0,0,0,411,53,1,0,0,0,412,410,1,0,0,0,413,414,
+	3,8,4,0,414,415,5,6,0,0,415,420,3,38,19,0,416,417,5,59,0,0,417,419,3,38,
+	19,0,418,416,1,0,0,0,419,422,1,0,0,0,420,418,1,0,0,0,420,421,1,0,0,0,421,
+	423,1,0,0,0,422,420,1,0,0,0,423,428,5,7,0,0,424,425,5,70,0,0,425,426,3,
+	10,5,0,426,427,5,70,0,0,427,429,1,0,0,0,428,424,1,0,0,0,428,429,1,0,0,0,
+	429,55,1,0,0,0,430,431,5,16,0,0,431,432,5,4,0,0,432,433,3,8,4,0,433,434,
+	5,5,0,0,434,437,1,0,0,0,435,437,3,8,4,0,436,430,1,0,0,0,436,435,1,0,0,0,
+	437,438,1,0,0,0,438,439,5,6,0,0,439,444,3,58,29,0,440,441,5,59,0,0,441,
+	443,3,58,29,0,442,440,1,0,0,0,443,446,1,0,0,0,444,442,1,0,0,0,444,445,1,
+	0,0,0,445,447,1,0,0,0,446,444,1,0,0,0,447,448,5,7,0,0,448,57,1,0,0,0,449,
+	450,6,29,-1,0,450,451,3,8,4,0,451,452,5,69,0,0,452,579,1,0,0,0,453,454,
+	3,8,4,0,454,455,7,2,0,0,455,456,5,68,0,0,456,579,1,0,0,0,457,458,3,8,4,
+	0,458,459,5,53,0,0,459,460,5,4,0,0,460,461,3,58,29,0,461,462,5,5,0,0,462,
+	463,5,68,0,0,463,579,1,0,0,0,464,579,5,22,0,0,465,466,5,21,0,0,466,467,
+	5,4,0,0,467,468,3,58,29,0,468,469,5,5,0,0,469,579,1,0,0,0,470,471,5,64,
+	0,0,471,476,3,52,26,0,472,473,5,67,0,0,473,475,3,52,26,0,474,472,1,0,0,
+	0,475,478,1,0,0,0,476,474,1,0,0,0,476,477,1,0,0,0,477,479,1,0,0,0,478,476,
+	1,0,0,0,479,480,5,65,0,0,480,579,1,0,0,0,481,579,3,28,14,0,482,579,3,30,
+	15,0,483,579,3,32,16,0,484,579,3,34,17,0,485,579,3,36,18,0,486,488,5,27,
+	0,0,487,486,1,0,0,0,487,488,1,0,0,0,488,489,1,0,0,0,489,490,5,42,0,0,490,
+	491,5,6,0,0,491,492,3,58,29,0,492,493,5,7,0,0,493,579,1,0,0,0,494,496,5,
+	27,0,0,495,494,1,0,0,0,495,496,1,0,0,0,496,497,1,0,0,0,497,498,5,43,0,0,
+	498,499,5,6,0,0,499,500,3,58,29,0,500,501,5,7,0,0,501,579,1,0,0,0,502,503,
+	5,44,0,0,503,504,5,4,0,0,504,505,3,58,29,0,505,506,5,5,0,0,506,507,5,6,
+	0,0,507,508,3,58,29,0,508,509,5,7,0,0,509,579,1,0,0,0,510,511,7,6,0,0,511,
+	512,5,6,0,0,512,513,3,58,29,0,513,514,5,7,0,0,514,579,1,0,0,0,515,516,5,
+	9,0,0,516,517,3,58,29,0,517,518,5,9,0,0,518,579,1,0,0,0,519,520,5,8,0,0,
+	520,521,3,58,29,0,521,522,5,8,0,0,522,579,1,0,0,0,523,579,3,12,6,0,524,
+	579,3,10,5,0,525,526,5,52,0,0,526,579,3,58,29,30,527,528,5,17,0,0,528,529,
+	5,4,0,0,529,530,3,58,29,0,530,531,5,5,0,0,531,532,5,4,0,0,532,533,3,58,
+	29,0,533,534,5,5,0,0,534,579,1,0,0,0,535,579,5,18,0,0,536,579,3,8,4,0,537,
+	579,3,54,27,0,538,579,3,56,28,0,539,579,5,11,0,0,540,541,5,6,0,0,541,542,
+	3,58,29,0,542,543,5,7,0,0,543,579,1,0,0,0,544,545,3,10,5,0,545,546,3,58,
+	29,12,546,579,1,0,0,0,547,548,3,12,6,0,548,549,3,58,29,11,549,579,1,0,0,
+	0,550,551,5,11,0,0,551,579,3,58,29,10,552,555,5,25,0,0,553,554,5,4,0,0,
+	554,556,5,5,0,0,555,553,1,0,0,0,555,556,1,0,0,0,556,579,1,0,0,0,557,558,
+	5,16,0,0,558,559,5,4,0,0,559,560,3,58,29,0,560,561,5,5,0,0,561,563,1,0,
+	0,0,562,557,1,0,0,0,562,563,1,0,0,0,563,567,1,0,0,0,564,568,5,60,0,0,565,
+	568,3,10,5,0,566,568,5,54,0,0,567,564,1,0,0,0,567,565,1,0,0,0,567,566,1,
+	0,0,0,567,568,1,0,0,0,568,569,1,0,0,0,569,570,5,16,0,0,570,571,5,4,0,0,
+	571,572,3,58,29,0,572,576,5,5,0,0,573,577,5,60,0,0,574,577,3,10,5,0,575,
+	577,5,54,0,0,576,573,1,0,0,0,576,574,1,0,0,0,576,575,1,0,0,0,576,577,1,
+	0,0,0,577,579,1,0,0,0,578,449,1,0,0,0,578,453,1,0,0,0,578,457,1,0,0,0,578,
+	464,1,0,0,0,578,465,1,0,0,0,578,470,1,0,0,0,578,481,1,0,0,0,578,482,1,0,
+	0,0,578,483,1,0,0,0,578,484,1,0,0,0,578,485,1,0,0,0,578,487,1,0,0,0,578,
+	495,1,0,0,0,578,502,1,0,0,0,578,510,1,0,0,0,578,515,1,0,0,0,578,519,1,0,
+	0,0,578,523,1,0,0,0,578,524,1,0,0,0,578,525,1,0,0,0,578,527,1,0,0,0,578,
+	535,1,0,0,0,578,536,1,0,0,0,578,537,1,0,0,0,578,538,1,0,0,0,578,539,1,0,
+	0,0,578,540,1,0,0,0,578,544,1,0,0,0,578,547,1,0,0,0,578,550,1,0,0,0,578,
+	552,1,0,0,0,578,562,1,0,0,0,579,642,1,0,0,0,580,581,10,29,0,0,581,582,5,
+	20,0,0,582,641,3,58,29,30,583,584,10,28,0,0,584,585,5,19,0,0,585,641,3,
+	58,29,29,586,587,10,25,0,0,587,588,5,52,0,0,588,641,3,58,29,26,589,590,
+	10,24,0,0,590,591,5,51,0,0,591,641,3,58,29,25,592,593,10,50,0,0,593,641,
+	7,2,0,0,594,595,10,49,0,0,595,596,5,53,0,0,596,597,5,4,0,0,597,598,3,58,
+	29,0,598,599,5,5,0,0,599,641,1,0,0,0,600,601,10,48,0,0,601,602,5,10,0,0,
+	602,603,5,4,0,0,603,604,3,58,29,0,604,605,5,59,0,0,605,606,3,58,29,0,606,
+	607,5,5,0,0,607,641,1,0,0,0,608,609,10,47,0,0,609,641,5,26,0,0,610,611,
+	10,18,0,0,611,612,5,10,0,0,612,613,5,4,0,0,613,641,5,5,0,0,614,615,10,17,
+	0,0,615,616,5,53,0,0,616,617,5,4,0,0,617,641,5,5,0,0,618,619,10,16,0,0,
+	619,641,3,8,4,0,620,621,10,15,0,0,621,641,3,10,5,0,622,623,10,14,0,0,623,
+	641,3,12,6,0,624,625,10,13,0,0,625,641,5,11,0,0,626,627,10,9,0,0,627,641,
+	3,54,27,0,628,629,10,8,0,0,629,641,3,56,28,0,630,631,10,7,0,0,631,641,3,
+	28,14,0,632,633,10,6,0,0,633,641,3,30,15,0,634,635,10,5,0,0,635,641,3,32,
+	16,0,636,637,10,4,0,0,637,641,3,34,17,0,638,639,10,3,0,0,639,641,3,36,18,
+	0,640,580,1,0,0,0,640,583,1,0,0,0,640,586,1,0,0,0,640,589,1,0,0,0,640,592,
+	1,0,0,0,640,594,1,0,0,0,640,600,1,0,0,0,640,608,1,0,0,0,640,610,1,0,0,0,
+	640,614,1,0,0,0,640,618,1,0,0,0,640,620,1,0,0,0,640,622,1,0,0,0,640,624,
+	1,0,0,0,640,626,1,0,0,0,640,628,1,0,0,0,640,630,1,0,0,0,640,632,1,0,0,0,
+	640,634,1,0,0,0,640,636,1,0,0,0,640,638,1,0,0,0,641,644,1,0,0,0,642,640,
+	1,0,0,0,642,643,1,0,0,0,643,59,1,0,0,0,644,642,1,0,0,0,645,646,7,7,0,0,
+	646,647,3,66,33,0,647,648,7,8,0,0,648,61,1,0,0,0,649,650,7,7,0,0,650,651,
+	7,9,0,0,651,652,7,10,0,0,652,653,7,9,0,0,653,654,7,8,0,0,654,63,1,0,0,0,
+	655,656,5,78,0,0,656,657,5,88,0,0,657,658,7,9,0,0,658,659,5,89,0,0,659,
+	660,5,88,0,0,660,661,5,91,0,0,661,664,5,89,0,0,662,664,5,79,0,0,663,655,
+	1,0,0,0,663,662,1,0,0,0,664,65,1,0,0,0,665,666,6,33,-1,0,666,667,5,82,0,
+	0,667,668,5,88,0,0,668,669,3,58,29,0,669,670,5,89,0,0,670,688,1,0,0,0,671,
+	672,5,78,0,0,672,675,5,88,0,0,673,676,3,66,33,0,674,676,5,90,0,0,675,673,
+	1,0,0,0,675,674,1,0,0,0,676,677,1,0,0,0,677,678,5,89,0,0,678,679,5,88,0,
+	0,679,680,3,66,33,0,680,681,5,89,0,0,681,688,1,0,0,0,682,688,5,85,0,0,683,
+	684,5,86,0,0,684,685,3,66,33,0,685,686,5,87,0,0,686,688,1,0,0,0,687,665,
+	1,0,0,0,687,671,1,0,0,0,687,682,1,0,0,0,687,683,1,0,0,0,688,711,1,0,0,0,
+	689,690,10,4,0,0,690,691,5,80,0,0,691,710,3,66,33,5,692,693,10,9,0,0,693,
+	694,5,84,0,0,694,710,5,91,0,0,695,696,10,8,0,0,696,697,5,84,0,0,697,698,
+	5,88,0,0,698,699,5,91,0,0,699,710,5,89,0,0,700,701,10,7,0,0,701,702,5,84,
+	0,0,702,710,3,64,32,0,703,704,10,6,0,0,704,705,5,84,0,0,705,706,5,88,0,
+	0,706,707,3,64,32,0,707,708,5,89,0,0,708,710,1,0,0,0,709,689,1,0,0,0,709,
+	692,1,0,0,0,709,695,1,0,0,0,709,700,1,0,0,0,709,703,1,0,0,0,710,713,1,0,
+	0,0,711,709,1,0,0,0,711,712,1,0,0,0,712,67,1,0,0,0,713,711,1,0,0,0,53,85,
+	99,102,115,131,144,149,156,161,166,175,185,190,195,203,213,225,239,250,
+	262,270,281,295,305,323,331,341,352,369,373,380,386,393,410,420,428,436,
+	444,476,487,495,555,562,567,576,578,640,642,663,675,687,709,711];
 
 	private static __ATN: ATN;
 	public static get _ATN(): ATN {
@@ -5122,6 +5135,12 @@ export class RemoveOperatorFontContext extends ExprContext {
 	}
 	public number_(i: number): NumberContext {
 		return this.getTypedRuleContext(NumberContext, i) as NumberContext;
+	}
+	public EQ_list(): TerminalNode[] {
+	    	return this.getTokens(LatexParser.EQ);
+	}
+	public EQ(i: number): TerminalNode {
+		return this.getToken(LatexParser.EQ, i);
 	}
 	// @Override
 	public accept<Result>(visitor: LatexParserVisitor<Result>): Result {

--- a/src/parser/LatexToSympy.ts
+++ b/src/parser/LatexToSympy.ts
@@ -2313,6 +2313,9 @@ export class LatexToSympy extends LatexParserVisitor<string | Statement | UnitBl
   visitMissingMultiplication = (ctx: MissingMultiplicationContext): string => {
     this.addParsingErrorMessage("Missing multiplication symbol in expression");
 
+    // need to visit sub expressions in case there are any immediate fixes that need to be applied
+    this.visit(ctx.expr());
+
     return '';
   }
 


### PR DESCRIPTION
Handles case that comes up in data tables where a variable name and an equals sign are inserted before a function name
