### PR TITLE
fix: properly identify no substituion case in intermediate results

### DIFF
--- a/src/MathCell.svelte
+++ b/src/MathCell.svelte
@@ -340,7 +340,8 @@
           newLatex = ` ${currentResultLatex.resultLatex}${currentResultLatex.resultUnitsLatex} `;
         }
 
-        if (startingLatex.slice(replacement.location, replacement.location+replacement.deletionLength) === newLatex.trim()) {
+        if (startingLatex.slice(replacement.location, replacement.location+replacement.deletionLength).replace(/[ \\{}]/g, '') === 
+            newLatex.trim().replace(/[ \\{}]/g, '')) {
           continue;
         }
 

--- a/tests/test_number_format.spec.mjs
+++ b/tests/test_number_format.spec.mjs
@@ -644,7 +644,10 @@ test('Test intermediate results with symbolic values', async () => {
 test('Test intermediate results with only symbolic values', async () => {
   await page.setLatex(0, String.raw`x\cdot y=`);
 
-  // turn on symbolic results 
+  await page.locator('#add-math-cell').click();
+  await page.setLatex(1, String.raw`\alpha_1\cdot a=`);
+
+  // turn on intermediate results 
   await page.getByRole('button', { name: 'Sheet Settings' }).click();
   await page.locator('label').filter({ hasText: 'Show Intermediate Results' }).click();
   await page.getByRole('button', { name: 'Confirm' }).click();
@@ -654,4 +657,7 @@ test('Test intermediate results with only symbolic values', async () => {
   // there should be no intermediate result
   let content = await page.textContent('#result-value-0');
   expect(content).toBe(String.raw`x \cdot y`);
+
+  content = await page.textContent('#result-value-1');
+  expect(content).toBe(String.raw`a \cdot \alpha_{1}`);
 });


### PR DESCRIPTION
For some cases, a_1 and a_{1} or omega and \omega weren't identified as being the same symbol
