### PR TITLE
fix: select the first inserted cell when inserting a sheet

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1679,6 +1679,10 @@ Please include a link to this sheet in the email to assist in debugging the prob
       }, 
       ...$insertedSheets
     ];
+
+    if (index <= $cells.length-1) {
+      $activeCell = index;
+    }
   }
 
 


### PR DESCRIPTION
Makes it obvious to the user where the insertion starts. Addresses issue raised in #293
