### PR TITLE
fix: fix interpolation function plotting bug

### DIFF
--- a/src/parser/LatexToSympy.ts
+++ b/src/parser/LatexToSympy.ts
@@ -1282,7 +1282,7 @@ export class LatexToSympy extends LatexParserVisitor<string | Statement | UnitBl
         unitQueryArgument.sympy = newArguments[0].sympy;
       } else {
         // numerical lower limit without units, replace with unitless implicit param to prevent cancelling
-        unitQueryArgument.sympy = this.getUnitlessImplicitParam();
+        unitQueryArgument.sympy = this.getUnitlessImplicitParam(newArguments[0].sympy);
       }
       
       unitQueryArgument.params = this.params.slice(initialParamCursor);
@@ -2083,13 +2083,11 @@ export class LatexToSympy extends LatexParserVisitor<string | Statement | UnitBl
     }
   }
 
-  getUnitlessImplicitParam(value=1): string {
+  getUnitlessImplicitParam(valueString:string): string {
     const newParamName = this.getNextParName();
 
     const units = 'm/m';
     const mathjsUnits = unit(units);
-
-    const valueString = value.toString();
 
     let param: ImplicitParameter = {
       name: newParamName,

--- a/tests/test_data_table.spec.mjs
+++ b/tests/test_data_table.spec.mjs
@@ -1356,3 +1356,35 @@ test('Test data table user function exponent bug', async () => {
   let content = await page.textContent(`#result-value-1`);
   expect(content).toBe(String.raw`\begin{bmatrix} 2\left\lbrack m\right\rbrack  \\ 4\left\lbrack m\right\rbrack  \\ 8\left\lbrack m\right\rbrack  \end{bmatrix}`);
 });
+
+test('Test linear interpolation with plotting', async () => {
+  const modifierKey = (await page.evaluate('window.modifierKey') )=== "metaKey" ? "Meta" : "Control";
+
+  await page.locator('#add-data-table-cell').click();
+
+  await page.locator('#data-table-input-1-0-0').click();
+
+  await page.keyboard.type('10');
+  await page.keyboard.press('Tab');
+  await page.keyboard.type('1');
+  await page.keyboard.press('Enter');
+
+  await page.keyboard.type('20');
+  await page.keyboard.press('Tab');
+  await page.keyboard.type('2');
+  await page.keyboard.press('Enter');
+
+  await page.keyboard.type('30');
+  await page.keyboard.press('Tab');
+  await page.keyboard.type('3');
+
+  await page.getByRole('button', { name: 'Add Interpolation' }).click();
+  await page.getByLabel('Copy function name to').click();
+
+  await page.locator('#cell-0 >> math-field.editable').type('(x,');
+  await page.locator('#cell-0 >> math-field.editable').press(modifierKey+'+v');
+  await page.locator('#cell-0 >> math-field.editable').type('(x)) for (10<=x<=30)=');
+
+  await page.waitForSelector('div.status-footer', {state: 'detached'});
+  await expect(page.locator('g.trace.scatter')).toBeVisible();
+});


### PR DESCRIPTION
Since lower limit unit check always occurred at x=1 for unitless lower limit, an error occurred if 1 was outside of the interpolation range
