### PR TITLE
fix: cache data table calculations

### DIFF
--- a/src/parser/LatexToSympy.ts
+++ b/src/parser/LatexToSympy.ts
@@ -795,7 +795,7 @@ export class LatexToSympy extends LatexParserVisitor<string | Statement | UnitBl
         isDataTableQuery: true,
         cellNum: -1,
         colId: this.dataTableInfo?.colId ?? -1,
-        sympy: `_data_table_calc_wrapper(${finalQuery.sympy})`
+        sympy: `_data_table_calc_wrapper_${this.equationIndex}(${finalQuery.sympy})`
       };
     }
 
@@ -943,7 +943,7 @@ export class LatexToSympy extends LatexParserVisitor<string | Statement | UnitBl
     let sympyExpression = this.visit(ctx.expr()) as string;
 
     if (this.dataTableInfo) {
-      sympyExpression = `_data_table_calc_wrapper(${sympyExpression})`;
+      sympyExpression = `_data_table_calc_wrapper_${this.equationIndex}(${sympyExpression})`;
     }
 
     if (this.rangeCount > 0) {

--- a/tests/test_code_cell.spec.mjs
+++ b/tests/test_code_cell.spec.mjs
@@ -2917,6 +2917,7 @@ import sympy as sp
 import math
 
 def calculate(Re, D, epsilon):
+    print(Re)
     # Use Churchill (1977) for an initial guess and for laminar or transition flow
     A = (-2.457*math.log((7/Re)**0.9+0.27*(epsilon/D)))**16.0
     B = (37530/Re)**16.0
@@ -2962,4 +2963,7 @@ def calculate(Re, D, epsilon):
   expect(parseLatexFloat(content)).toBeCloseTo(0.0271697911785628, precision);
   content = await page.textContent('#result-units-4');
   expect(content).toBe('');
+
+  // check code cell evaluation caching
+  await expect(page.locator('#cell-1 >> text=64.0')).toHaveText('64.0\n64.0\n20000.0\n');
 });


### PR DESCRIPTION
Data table calculations were being repeated for every location that the result was used. This makes sure that data table calculations are only performed once per sheet pass. This is important since data table calculations can be quite expensive for large tables.