### PR TITLE
fix: fix parser crash

### DIFF
--- a/src/parser/LatexToSympy.ts
+++ b/src/parser/LatexToSympy.ts
@@ -1173,7 +1173,7 @@ export class LatexToSympy extends LatexParserVisitor<string | Statement | UnitBl
       }
 
     } else {
-      if (ctx.expr(0).children[0] instanceof Number_with_unitsContext) {
+      if (ctx.expr(0).children[0] instanceof Number_with_unitsContext && (ctx.expr(0).children[0] as Number_with_unitsContext).number_()) {
         if ((ctx.expr(0).children[0] as Number_with_unitsContext).number_().NUMBER().toString().search(/\\cdot|\\times/) >= 0) {
           this.addParsingErrorMessage("Exponent cannot be applied directly to a number with units when using scientific notation, enclose the number with units in parenthesis and then add the exponent to eliminate this order of operations ambiguity. Correct example: (2*10^2[m])^3");
         }

--- a/tests/test_basic.spec.mjs
+++ b/tests/test_basic.spec.mjs
@@ -1939,6 +1939,12 @@ test('Test error units applied to variable name', async () => {
   await expect(page.locator('#cell-0 >> text=Units cannot be applied directly to a variable name')).toBeVisible();
 });
 
+test('Test error units applied to variable name then raised to an exponent', async () => {
+  await page.setLatex(0, String.raw`f\left\lbrack m\right\rbrack^2=`);
+
+  await expect(page.locator('#cell-0 >> text=Units cannot be applied directly to a variable name')).toBeVisible();
+});
+
 test('Test slow simplification issue', async ({ browserName }) => {
   test.skip(browserName === "chromium", "Playwright does not currently support the File System Access API");
 


### PR DESCRIPTION
Parser crashed when variable with units is raised to a power. This fix provides a useful error message so that the user can fix the issue.