### PR TITLE
fix: auto fix square brackets

### DIFF
--- a/src/parser/LatexToSympy.ts
+++ b/src/parser/LatexToSympy.ts
@@ -2263,14 +2263,32 @@ export class LatexToSympy extends LatexParserVisitor<string | Statement | UnitBl
     let unitsDimensions: number[] = [];
 
     if(ctx) {
+      const startIndex = ctx.start.column;
+      const stopIndex = ctx.stop.column + ctx.stop.text.length;
+
       units = this.visit(ctx.u_expr()) as string;
-      unitsLatex = `\\left${this.sourceLatex.slice(
-        ctx.start.column,
-        ctx.stop.column + ctx.stop.text.length
-      )}`;
-      if (!/\\right\s*\]/.test(unitsLatex)) {
-        unitsLatex = unitsLatex.replace(']', '\\right]');
+      unitsLatex = `\\left${this.sourceLatex.slice(startIndex, stopIndex)}`;
+      if (!/\\right\s*(?:\]|\\rbrack)/.test(unitsLatex)) {
+        unitsLatex = unitsLatex.replace(/\]|\\rbrack/, match => '\\right' + match);
+
+        const sliceAfterStart = this.sourceLatex.slice(startIndex);
+        const rightMatch = sliceAfterStart.match(/\]|\\rbrack/);
+        const rightLocation = rightMatch ? startIndex + rightMatch.index : -1;
+        this.pendingEdits.push({
+          type: "insertion",
+          location: rightLocation,
+          text: '\\right'
+        });
       }
+
+      if (!/\\left\s*$/.test(this.sourceLatex.slice(0, startIndex))) {
+        this.pendingEdits.push({
+          type: "insertion",
+          location: startIndex,
+          text: '\\left'
+        });
+      }
+
       const { dimensions, unitsValid } = checkUnits(units);
       if (unitsValid) {
         unitsDimensions = dimensions;

--- a/tests/test_matrix_keyboard.spec.mjs
+++ b/tests/test_matrix_keyboard.spec.mjs
@@ -127,3 +127,39 @@ test('Matrix with more than 10 columns', async () => {
   let content = await page.textContent(`#result-value-0`);
   expect(content).toBe(String.raw`\begin{bmatrix} a & b & c & d & e0 & f & g & h & i0 & j & k \end{bmatrix}`);
 });
+
+test('Test autofix square braces', async () => {
+  await page.setLatex(0, String.raw`\begin{bmatrix}1\\ 2\end{bmatrix}\cdot1[\frac{m}{V}]=[\frac{m}{V}]`);
+
+  await page.locator('#add-math-cell').click();
+  await page.setLatex(1, String.raw`\begin{bmatrix}1 & 2\end{bmatrix}\cdot1[\frac{m}{V}]=\left[\frac{m}{V}\right]`);
+
+  await page.locator('#add-math-cell').click();
+  await page.setLatex(2, String.raw`\begin{bmatrix}1 & 2\end{bmatrix}\cdot1\left[\frac{m}{V}\right]=\left [\frac{m}{V}\right ]`);
+
+  await page.locator('#add-math-cell').click();
+  await page.setLatex(3, String.raw`\begin{bmatrix}1 & 2\end{bmatrix}\cdot2\left[\frac{m}{V}\right]=\lbrack\frac{m}{V}\rbrack`);
+
+  await page.locator('#add-math-cell').click();
+  await page.setLatex(4, String.raw`\begin{bmatrix}1 & 2\end{bmatrix}\cdot2\left[\frac{m}{V}\right]=\left \lbrack\frac{m}{V}\right \rbrack`);
+
+  await page.waitForSelector('text=Updating...', {state: 'detached'});
+
+  await page.keyboard.press('Escape');
+
+  let content = await page.textContent(`#result-value-0`);
+  expect(content).toBe(String.raw`=\begin{bmatrix} 1\left[\frac{m}{V}\right] \\ 2\left[\frac{m}{V}\right] \end{bmatrix}`);
+
+  content = await page.textContent(`#result-value-1`);
+  expect(content).toBe(String.raw`=\begin{bmatrix} 1\left[\frac{m}{V}\right] & 2\left[\frac{m}{V}\right] \end{bmatrix}`);
+
+  content = await page.textContent(`#result-value-2`);
+  expect(content).toBe(String.raw`=\begin{bmatrix} 1\left[\frac{m}{V}\right ] & 2\left[\frac{m}{V}\right ] \end{bmatrix}`);
+
+  content = await page.textContent(`#result-value-3`);
+  expect(content).toBe(String.raw`=\begin{bmatrix} 2\left\lbrack\frac{m}{V}\right\rbrack & 4\left\lbrack\frac{m}{V}\right\rbrack \end{bmatrix}`);
+
+  content = await page.textContent(`#result-value-4`);
+  expect(content).toBe(String.raw`=\begin{bmatrix} 2\left\lbrack\frac{m}{V}\right \rbrack & 4\left\lbrack\frac{m}{V}\right \rbrack \end{bmatrix}`);
+  
+});


### PR DESCRIPTION
Some keyboard configurations insert plain square brackets instead of \left[ or \left\lbrack and \right] or \right\rbrack. This  gives the correct results but the rendering of the brackets doesn't grow with the content. This fix inserts \left and \right where needed

